### PR TITLE
Fix Redis cache fallback initialization

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -9,7 +9,6 @@ import compressionMiddleware from "./middleware/compression";
 import { securityMiddleware, sanitizeInput, securityMonitoring, ipSecurity } from "./middleware/security";
 import { rateLimiters, logRateLimitViolations, dynamicRateLimiter } from "./middleware/rate-limiter";
 import { CDNOptimizationService } from "./services/cdn-optimization";
-import { RedisCache } from "./services/redis-cache";
 import { DatabasePoolManager } from "./services/database-pool";
 // Monitoring imports are handled in routes.ts
 

--- a/server/routes/scalability.ts
+++ b/server/routes/scalability.ts
@@ -7,7 +7,7 @@
 import { Request, Response, Router } from 'express';
 import { scalabilityOrchestrator } from '../services/scalability-orchestrator';
 import { loadBalancer } from '../services/load-balancer';
-import { RedisCache } from '../services/redis-cache';
+import { redisCache } from '../services/redis-cache';
 import { DatabasePoolManager } from '../services/database-pool';
 import { CDNOptimizationService } from '../services/cdn-optimization';
 import { createLogger } from '../utils/logger';
@@ -16,7 +16,6 @@ const logger = createLogger('scalability-routes');
 const router = Router();
 
 // Initialize services
-const redisCache = new RedisCache();
 const dbPool = new DatabasePoolManager();
 const cdnService = new CDNOptimizationService();
 

--- a/server/services/redis-cache.ts
+++ b/server/services/redis-cache.ts
@@ -168,7 +168,7 @@ export class RedisCache {
       const serialized = JSON.stringify(value);
       const expiry = ttl || this.defaultTTL;
 
-      await client.setex(key, expiry, serialized);
+      await client.setEx(key, expiry, serialized);
     } catch (error) {
       logger.error(`Failed to set cache key ${key}:`, error);
     }

--- a/server/services/redis-cache.ts
+++ b/server/services/redis-cache.ts
@@ -8,61 +8,151 @@ import Redis from 'ioredis';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('redis-cache');
+const RETRY_DELAY_MS = parseInt(process.env.REDIS_RETRY_DELAY_MS || '60000', 10);
+
+const DEFAULT_REDIS_URL = 'redis://localhost:6379';
 
 export class RedisCache {
   private client: Redis | null = null;
   private isConnected = false;
   private defaultTTL = 3600; // 1 hour default
+  private initializing: Promise<void> | null = null;
+  private nextRetryAt = 0;
+  private disabled = false;
+  private redisUrl: string | null = null;
 
   constructor() {
-    this.initialize();
+    const configuredUrl = process.env.REDIS_URL?.trim();
+
+    if (!configuredUrl) {
+      if (process.env.NODE_ENV === 'production') {
+        logger.warn('REDIS_URL not configured. Redis cache disabled.');
+        this.disabled = true;
+        return;
+      }
+
+      logger.info(`REDIS_URL not configured. Falling back to ${DEFAULT_REDIS_URL} for development.`);
+      this.redisUrl = DEFAULT_REDIS_URL;
+      return;
+    }
+
+    this.redisUrl = configuredUrl;
   }
 
-  private async initialize() {
+  private async ensureClient(): Promise<Redis | null> {
+    if (this.disabled) return null;
+
+    if (this.client && this.isConnected) {
+      return this.client;
+    }
+
+    if (Date.now() < this.nextRetryAt) {
+      return null;
+    }
+
+    if (!this.initializing) {
+      this.initializing = this.initialize();
+    }
+
     try {
-      // In production, use REDIS_URL from environment
-      const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
-      
-      this.client = new Redis(redisUrl, {
-        retryStrategy: (times) => {
-          if (times > 10) {
-            logger.error('Redis connection failed after 10 retries');
-            return null;
-          }
-          return Math.min(times * 100, 3000);
-        },
-        maxRetriesPerRequest: 3,
-        enableReadyCheck: true,
-        lazyConnect: false
+      await this.initializing;
+    } finally {
+      this.initializing = null;
+    }
+
+    return this.client && this.isConnected ? this.client : null;
+  }
+
+  private async initialize(): Promise<void> {
+    if (this.disabled) return;
+
+    const redisUrl = this.redisUrl || process.env.REDIS_URL?.trim();
+    if (!redisUrl) {
+      logger.warn('Redis URL unavailable. Disabling cache service.');
+      this.disabled = true;
+      return;
+    }
+
+    this.redisUrl = redisUrl;
+
+    if (this.client) {
+      try {
+        this.client.removeAllListeners();
+        this.client.disconnect();
+      } catch (error) {
+        logger.debug('Error cleaning up previous Redis client', error);
+      }
+      this.client = null;
+    }
+
+    try {
+      const client = new Redis(redisUrl, {
+        lazyConnect: true,
+        maxRetriesPerRequest: 0,
+        enableReadyCheck: false,
+        retryStrategy: () => null
       });
 
-      this.client.on('error', (err) => {
+      client.on('error', (err) => {
         logger.error('Redis Client Error:', err);
-        this.isConnected = false;
+        this.handleConnectionLoss();
       });
 
-      this.client.on('connect', () => {
+      client.on('close', () => {
+        logger.warn('Redis connection closed');
+        this.handleConnectionLoss();
+      });
+
+      client.on('end', () => {
+        logger.warn('Redis connection ended');
+        this.handleConnectionLoss();
+      });
+
+      client.on('connect', () => {
         logger.info('Redis connected successfully');
-        this.isConnected = true;
       });
 
-      this.client.on('ready', () => {
+      client.on('ready', () => {
         logger.info('Redis ready to accept commands');
         this.isConnected = true;
+        this.nextRetryAt = 0;
       });
+
+      await client.connect();
+
+      this.client = client;
+      this.isConnected = true;
+      this.nextRetryAt = 0;
     } catch (error) {
       logger.error('Failed to initialize Redis:', error);
-      // Graceful degradation - app continues without cache
+      this.handleConnectionLoss();
     }
   }
 
+  private handleConnectionLoss() {
+    this.isConnected = false;
+    this.nextRetryAt = Date.now() + RETRY_DELAY_MS;
+
+    if (this.client) {
+      try {
+        this.client.removeAllListeners();
+        this.client.disconnect();
+      } catch (error) {
+        logger.debug('Error while disconnecting Redis client', error);
+      }
+    }
+
+    this.client = null;
+  }
+
   async get<T>(key: string): Promise<T | null> {
-    if (!this.isConnected || !this.client) return null;
-    
+    const client = await this.ensureClient();
+    if (!client) return null;
+
     try {
-      const data = await this.client.get(key);
+      const data = await client.get(key);
       if (!data) return null;
-      
+
       return JSON.parse(data) as T;
     } catch (error) {
       logger.error(`Failed to get cache key ${key}:`, error);
@@ -71,36 +161,39 @@ export class RedisCache {
   }
 
   async set(key: string, value: any, ttl?: number): Promise<void> {
-    if (!this.isConnected || !this.client) return;
-    
+    const client = await this.ensureClient();
+    if (!client) return;
+
     try {
       const serialized = JSON.stringify(value);
       const expiry = ttl || this.defaultTTL;
-      
-      await this.client.setEx(key, expiry, serialized);
+
+      await client.setex(key, expiry, serialized);
     } catch (error) {
       logger.error(`Failed to set cache key ${key}:`, error);
     }
   }
 
   async del(key: string | string[]): Promise<void> {
-    if (!this.isConnected || !this.client) return;
-    
+    const client = await this.ensureClient();
+    if (!client) return;
+
     try {
       const keys = Array.isArray(key) ? key : [key];
       if (keys.length > 0) {
-        await this.client.del(keys);
+        await client.del(...keys);
       }
     } catch (error) {
-      logger.error(`Failed to delete cache keys:`, error);
+      logger.error('Failed to delete cache keys:', error);
     }
   }
 
   async flush(): Promise<void> {
-    if (!this.isConnected || !this.client) return;
-    
+    const client = await this.ensureClient();
+    if (!client) return;
+
     try {
-      await this.client.flushAll();
+      await client.flushall();
       logger.info('Redis cache flushed');
     } catch (error) {
       logger.error('Failed to flush cache:', error);
@@ -121,12 +214,13 @@ export class RedisCache {
 
   // Invalidate related cache keys
   async invalidatePattern(pattern: string): Promise<void> {
-    if (!this.isConnected || !this.client) return;
-    
+    const client = await this.ensureClient();
+    if (!client) return;
+
     try {
-      const keys = await this.client.keys(pattern);
+      const keys = await client.keys(pattern);
       if (keys.length > 0) {
-        await this.client.del(keys);
+        await client.del(...keys);
         logger.info(`Invalidated ${keys.length} cache keys matching pattern: ${pattern}`);
       }
     } catch (error) {
@@ -135,35 +229,36 @@ export class RedisCache {
   }
 
   // Rate limiting implementation
-  async checkRateLimit(key: string, limit: number, window: number): Promise<{
-    allowed: boolean;
-    remaining: number;
-    reset: number;
-  }> {
-    if (!this.isConnected || !this.client) {
+  async checkRateLimit(
+    key: string,
+    limit: number,
+    window: number
+  ): Promise<{ allowed: boolean; remaining: number; reset: number; }> {
+    const client = await this.ensureClient();
+    if (!client) {
       return { allowed: true, remaining: limit, reset: 0 };
     }
 
     try {
-      const multi = this.client.multi();
+      const multi = client.multi();
       const now = Date.now();
       const windowStart = now - window * 1000;
-      
+
       // Remove old entries
       multi.zremrangebyscore(key, '-inf', windowStart.toString());
-      
+
       // Add current request
       multi.zadd(key, now, now.toString());
-      
+
       // Count requests in window
       multi.zcard(key);
-      
+
       // Set expiry
       multi.expire(key, window);
-      
+
       const results = await multi.exec();
       const count = (results?.[2]?.[1] || 0) as number;
-      
+
       return {
         allowed: count <= limit,
         remaining: Math.max(0, limit - count),
@@ -190,10 +285,11 @@ export class RedisCache {
 
   // Health check
   async healthCheck(): Promise<boolean> {
-    if (!this.isConnected || !this.client) return false;
-    
+    const client = await this.ensureClient();
+    if (!client) return false;
+
     try {
-      await this.client.ping();
+      await client.ping();
       return true;
     } catch {
       return false;

--- a/server/services/redis-cache.ts
+++ b/server/services/redis-cache.ts
@@ -193,7 +193,7 @@ export class RedisCache {
     if (!client) return;
 
     try {
-      await client.flushall();
+      await client.flushAll();
       logger.info('Redis cache flushed');
     } catch (error) {
       logger.error('Failed to flush cache:', error);

--- a/server/services/scalability-orchestrator.ts
+++ b/server/services/scalability-orchestrator.ts
@@ -7,7 +7,7 @@
 
 import { EventEmitter } from 'events';
 import { createLogger } from '../utils/logger';
-import { RedisCache } from './redis-cache';
+import { RedisCache, redisCache } from './redis-cache';
 import { DatabasePoolManager } from './database-pool';
 import { CDNOptimizationService } from './cdn-optimization';
 import { spawn, ChildProcess } from 'child_process';
@@ -74,7 +74,7 @@ export class ScalabilityOrchestrator extends EventEmitter {
 
   private constructor() {
     super();
-    this.redisCache = new RedisCache();
+    this.redisCache = redisCache;
     this.dbPool = new DatabasePoolManager();
     this.cdnService = new CDNOptimizationService();
     this.initialize();


### PR DESCRIPTION
## Summary
- restore a development fallback Redis URL while keeping production caches disabled when misconfigured
- persist the resolved Redis URL across retries and use the correct `setex` command to store values without runtime errors

## Testing
- npm run test *(fails: package.json is invalid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68f24b6b544883209828c643d36e9474