### PR TITLE
Add helper to clear stale git index lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,14 @@ See the following files for detailed information:
 ## 📄 License
 
 MIT License - see LICENSE file for details
+
+### 🛠️ Troubleshooting
+
+#### Git index lock prevents new commands
+If Git reports `fatal: Unable to create '.../.git/index.lock': File exists`, a previous command may have terminated unexpectedly. Run the helper script to safely remove the stale lock:
+
+```bash
+./scripts/cleanup-git-lock.sh
+```
+
+The script verifies that the repository exists, removes the stale `.git/index.lock` file when necessary, and leaves a confirmation message so you know whether any cleanup was required.

--- a/scripts/cleanup-git-lock.sh
+++ b/scripts/cleanup-git-lock.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+LOCK_FILE="$REPO_ROOT/.git/index.lock"
+
+if [ ! -d "$REPO_ROOT/.git" ]; then
+  echo "Error: unable to find .git directory from $REPO_ROOT" >&2
+  exit 1
+fi
+
+if [ -f "$LOCK_FILE" ]; then
+  rm -f "$LOCK_FILE"
+  echo "Removed stale git index lock at $LOCK_FILE"
+else
+  echo "No git index lock found at $LOCK_FILE"
+fi


### PR DESCRIPTION
## Summary
- add a cleanup script to remove a stale .git/index.lock when present
- document the troubleshooting step in the README so contributors can recover quickly

## Testing
- ./scripts/cleanup-git-lock.sh

------
https://chatgpt.com/codex/tasks/task_e_68f3d2bf45c48320860cd80cc4e2b64c