### PR TITLE
Update funding messaging to reflect Series A raise

### DIFF
--- a/attached_assets/Pasted--E-Code-Platform-Fortune-500-Pitch-Deck-Slide-1-Cover-E-Code-The-Future-of-Cloud-Developm-1754421060739_1754421060742.txt
+++ b/attached_assets/Pasted--E-Code-Platform-Fortune-500-Pitch-Deck-Slide-1-Cover-E-Code-The-Future-of-Cloud-Developm-1754421060739_1754421060742.txt
@@ -285,25 +285,25 @@
 ---
 
 ## Slide 14: Funding Requirements
-### **$15M Series A to Dominate Market**
+### **$25M Series A to accelerate global adoption**
 
 #### **Use of Funds (18-Month Runway):**
-- **Engineering & AI (50% - $7.5M)**: Scale team, enhance AI capabilities
-- **Sales & Marketing (30% - $4.5M)**: Enterprise go-to-market execution
-- **Infrastructure & GPU (15% - $2.25M)**: Global expansion, compute capacity
-- **Operations & Compliance (5% - $750K)**: Legal, security, enterprise readiness
+- **Engineering & AI (50% - $12.5M)**: Scale team, enhance AI capabilities
+- **Sales & Marketing (30% - $7.5M)**: Enterprise go-to-market execution
+- **Infrastructure & GPU (15% - $3.75M)**: Global expansion, compute capacity
+- **Operations & Compliance (5% - $1.25M)**: Legal, security, enterprise readiness
 
 #### **18-Month Milestones:**
 - **500K total users**, 100K paying subscribers
 - **$50M ARR run rate**
 - **100+ enterprise customers** (Fortune 5000)
 - **International expansion**: EU and APAC operations
-- **Series B readiness**: $200M+ valuation target
+- **Next-stage growth optionality**: Profitability milestones toward $200M+ valuation
 
 #### **Investment Terms:**
-- **Pre-money Valuation**: $60M
-- **Post-money Valuation**: $75M
-- **Use of funds**: Achieve profitability and Series B readiness
+- **Pre-money Valuation**: $80M
+- **Post-money Valuation**: $105M
+- **Use of funds**: Scale global adoption and reach profitability
 - **Board composition**: 2 investor seats, quarterly reporting
 
 ---

--- a/attached_assets/Pasted--E-Code-Platform-Pitch-Deck-Slide-1-Cover-E-Code-The-Future-of-Cloud-Development-Buil-1754420112633_1754420112636.txt
+++ b/attached_assets/Pasted--E-Code-Platform-Pitch-Deck-Slide-1-Cover-E-Code-The-Future-of-Cloud-Development-Buil-1754420112633_1754420112636.txt
@@ -224,24 +224,24 @@
 ---
 
 ## Slide 13: Funding Requirements
-### $10M Series A to Accelerate Growth
+### $25M Series A to accelerate global adoption
 
 **Use of Funds:**
-- **Engineering (50% - $5M)**: Scale development team, AI improvements
-- **Sales & Marketing (30% - $3M)**: Go-to-market execution
-- **Infrastructure (15% - $1.5M)**: Global expansion, GPU capacity
-- **Operations (5% - $500K)**: Legal, finance, HR
+- **Engineering (50% - $12.5M)**: Scale development team, AI improvements
+- **Sales & Marketing (30% - $7.5M)**: Go-to-market execution
+- **Infrastructure (15% - $3.75M)**: Global expansion, GPU capacity
+- **Operations (5% - $1.25M)**: Legal, finance, HR
 
 **Key Milestones (18 months):**
 - **100K total users**, 25K paying
 - **$15M ARR run rate**
 - **Enterprise customers**: 50+ companies
 - **International expansion**: EU, APAC regions
-- **Series B readiness**: $100M+ valuation
+- **Next-stage growth optionality**: Profitability milestones toward $150M+ valuation
 
 **Investment Terms:**
-- **Valuation**: $40M pre-money
-- **Use of funds**: 18-month runway to profitability
+- **Valuation**: $80M pre-money ($105M post-money)
+- **Use of funds**: 18-month runway to global scale and profitability
 - **Board composition**: 2 investor seats
 
 ---

--- a/client/src/pages/About.tsx
+++ b/client/src/pages/About.tsx
@@ -106,7 +106,7 @@ export default function About() {
           <div className="text-center space-y-5 sm:space-y-7">
             <Badge variant="secondary" className="mb-2 sm:mb-4 text-xs sm:text-sm">
               <Sparkles className="h-3 w-3 mr-1" />
-              Series B funded · 2025 global launch
+              Series A raise in progress · Targeting $25M for global launch
             </Badge>
             <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold">
               Orchestrating the <span className="text-primary">Vibe coding era</span> for global enterprises
@@ -183,8 +183,12 @@ export default function About() {
               <Card className="relative">
                 <CardContent className="p-8">
                   <div className="text-center space-y-6">
-                    <div className="text-6xl font-bold text-primary">$180M</div>
-                    <p className="text-xl font-semibold">Series B capital to scale the Vibe platform</p>
+                    <div className="text-6xl font-bold text-primary">$25M</div>
+                    <p className="text-xl font-semibold">Series A growth capital powering the Vibe platform</p>
+                    <p className="text-sm text-muted-foreground max-w-md mx-auto">
+                      The raise accelerates enterprise go-to-market, compliance automation, and sovereign-ready
+                      infrastructure investments so customers can scale with confidence.
+                    </p>
                     <div className="grid grid-cols-3 gap-4 pt-4">
                       <div>
                         <div className="text-2xl font-bold">2025</div>

--- a/client/src/pages/admin/PitchDeck.tsx
+++ b/client/src/pages/admin/PitchDeck.tsx
@@ -1116,11 +1116,11 @@ export default function PitchDeck() {
     // Slide 14: Funding Requirements
     {
       title: "Funding Requirements",
-      subtitle: "$15M Series A to Dominate Market",
+      subtitle: "$25M Series A to accelerate global adoption",
       content: (
         <div className="h-full overflow-y-auto">
           <h2 className="text-4xl font-bold mb-8 text-center bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
-            $15M Series A to Dominate Market
+            $25M Series A to accelerate global adoption
           </h2>
           
           <div className="grid grid-cols-2 gap-8 mb-8">
@@ -1130,7 +1130,7 @@ export default function PitchDeck() {
                 <div>
                   <div className="flex justify-between items-center mb-2">
                     <span className="font-semibold">Engineering & AI</span>
-                    <span className="text-xl font-bold text-blue-600">50% - $7.5M</span>
+                    <span className="text-xl font-bold text-blue-600">50% - $12.5M</span>
                   </div>
                   <div className="bg-blue-200 rounded-full h-4 overflow-hidden">
                     <div className="bg-blue-600 h-full" style={{width: '50%'}}></div>
@@ -1141,7 +1141,7 @@ export default function PitchDeck() {
                 <div>
                   <div className="flex justify-between items-center mb-2">
                     <span className="font-semibold">Sales & Marketing</span>
-                    <span className="text-xl font-bold text-green-600">30% - $4.5M</span>
+                    <span className="text-xl font-bold text-green-600">30% - $7.5M</span>
                   </div>
                   <div className="bg-green-200 rounded-full h-4 overflow-hidden">
                     <div className="bg-green-600 h-full" style={{width: '30%'}}></div>
@@ -1152,7 +1152,7 @@ export default function PitchDeck() {
                 <div>
                   <div className="flex justify-between items-center mb-2">
                     <span className="font-semibold">Infrastructure & GPU</span>
-                    <span className="text-xl font-bold text-purple-600">15% - $2.25M</span>
+                    <span className="text-xl font-bold text-purple-600">15% - $3.75M</span>
                   </div>
                   <div className="bg-purple-200 rounded-full h-4 overflow-hidden">
                     <div className="bg-purple-600 h-full" style={{width: '15%'}}></div>
@@ -1163,7 +1163,7 @@ export default function PitchDeck() {
                 <div>
                   <div className="flex justify-between items-center mb-2">
                     <span className="font-semibold">Operations & Compliance</span>
-                    <span className="text-xl font-bold text-orange-600">5% - $750K</span>
+                    <span className="text-xl font-bold text-orange-600">5% - $1.25M</span>
                   </div>
                   <div className="bg-orange-200 rounded-full h-4 overflow-hidden">
                     <div className="bg-orange-600 h-full" style={{width: '5%'}}></div>
@@ -1206,8 +1206,8 @@ export default function PitchDeck() {
                   <li className="flex items-start">
                     <TrendingUp className="w-5 h-5 mt-1 mr-3 text-green-600 flex-shrink-0" />
                     <div>
-                      <p className="font-semibold">Series B readiness</p>
-                      <p className="text-sm text-gray-600">$200M+ valuation target</p>
+                      <p className="font-semibold">Next-stage growth optionality</p>
+                      <p className="text-sm text-gray-600">Profitability milestones with a path toward $200M+ valuation</p>
                     </div>
                   </li>
                 </ul>
@@ -1218,15 +1218,15 @@ export default function PitchDeck() {
                 <div className="space-y-2">
                   <div className="flex justify-between">
                     <span>Pre-money Valuation:</span>
-                    <span className="font-bold">$60M</span>
+                    <span className="font-bold">$80M</span>
                   </div>
                   <div className="flex justify-between">
                     <span>Post-money Valuation:</span>
-                    <span className="font-bold">$75M</span>
+                    <span className="font-bold">$105M</span>
                   </div>
                   <div className="flex justify-between">
                     <span>Use of funds:</span>
-                    <span className="font-bold">Achieve profitability</span>
+                    <span className="font-bold">Scale global adoption and reach profitability</span>
                   </div>
                   <div className="flex justify-between">
                     <span>Board composition:</span>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1993,7 +1993,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
           { year: '2022', event: 'E-Code founded with a vision to create the Vibe coding platform.' },
           { year: '2023', event: 'Launched private alpha with design partners across three continents.' },
           { year: '2024', event: 'Secured lighthouse enterprise customers and orchestrated 5,000 pilot launches.' },
-          { year: 'Q1 2025', event: 'Announced $180M Series B funding and global debut of the Vibe platform.' },
+          {
+            year: 'Q1 2025',
+            event: 'Launched Series A fundraising targeting $25M to accelerate the global debut of the Vibe platform.'
+          },
           { year: 'Q3 2025', event: 'Expanded Fortune 500 partnerships with managed compliance and AI governance.' }
         ],
         team: [


### PR DESCRIPTION
## Summary
- update the public about page to highlight the active $25M Series A raise with refreshed supporting copy
- align server-provided milestones and the admin pitch deck with Series A targets and updated valuation assumptions
- refresh stored pitch deck asset content so offline materials match the Series A messaging

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68f47669c7dc83208b3aab747b7910c2