### PR TITLE
Ensure project navigation falls back to ID routes

### DIFF
--- a/client/src/components/ProjectTemplates.tsx
+++ b/client/src/components/ProjectTemplates.tsx
@@ -22,6 +22,7 @@ import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { apiRequest } from '@/lib/queryClient';
+import { getProjectUrl } from '@/lib/utils';
 import { useLocation } from 'wouter';
 
 interface Template {
@@ -123,7 +124,8 @@ export function ProjectTemplates({ onSelectTemplate, showCreateButton = true }: 
         description: `"${project.name}" has been created successfully.`,
       });
       // Navigate to the project with AI agent activated
-      navigate(`/@${project.owner?.username || user?.username}/${project.slug}?agent=true&prompt=Enhance this ${project.name} template`);
+      const projectUrl = getProjectUrl(project, project.owner?.username || user?.username);
+      navigate(`${projectUrl}?agent=true&prompt=Enhance this ${project.name} template`);
       setShowCreateDialog(false);
       setShowPreviewDialog(false);
       setProjectName('');

--- a/client/src/components/SpotlightSearch.tsx
+++ b/client/src/components/SpotlightSearch.tsx
@@ -53,6 +53,7 @@ import {
 import { useAuth } from '@/hooks/use-auth';
 import { useQuery } from '@tanstack/react-query';
 import { apiRequest } from '@/lib/queryClient';
+import { getProjectUrl } from '@/lib/utils';
 import type { Project } from '@shared/schema';
 
 export function SpotlightSearch() {
@@ -308,7 +309,7 @@ export function SpotlightSearch() {
               {recentProjects.slice(0, 5).map((project) => (
                 <CommandItem
                   key={project.id}
-                  onSelect={() => handleSelect(() => navigate(`/${project.slug}`))}
+                  onSelect={() => handleSelect(() => navigate(getProjectUrl(project, project.owner?.username)))}
                 >
                   <FileText className="h-4 w-4 mr-2" />
                   <span>{project.name}</span>

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -78,7 +78,21 @@ export function formatBytes(bytes: number, decimals: number = 2): string {
  * Build the canonical workspace URL for a project.
  * Falls back to ID-based routing when the slug or username is unavailable.
  */
-export function getProjectUrl(project: any, fallbackUsername?: string | null): string {
+interface ProjectOwnerLike {
+  username?: string | null;
+}
+
+interface ProjectLike {
+  slug?: string | null;
+  projectSlug?: string | null;
+  owner?: ProjectOwnerLike | null;
+  ownerUsername?: string | null;
+  owner_name?: string | null;
+  id?: number | string | null;
+  projectId?: number | string | null;
+}
+
+export function getProjectUrl(project: ProjectLike, fallbackUsername?: string | null): string {
   if (!project) {
     return '/projects';
   }

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -64,12 +64,44 @@ export function getRandomColor(input?: string): string {
  */
 export function formatBytes(bytes: number, decimals: number = 2): string {
   if (bytes === 0) return '0 Bytes';
-  
+
   const k = 1024;
   const dm = decimals < 0 ? 0 : decimals;
   const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-  
+
   const i = Math.floor(Math.log(bytes) / Math.log(k));
-  
+
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+}
+
+/**
+ * Build the canonical workspace URL for a project.
+ * Falls back to ID-based routing when the slug or username is unavailable.
+ */
+export function getProjectUrl(project: any, fallbackUsername?: string | null): string {
+  if (!project) {
+    return '/projects';
+  }
+
+  const slug = project.slug ?? project.projectSlug ?? null;
+  const ownerUsername =
+    project.owner?.username ??
+    project.ownerUsername ??
+    project.owner_name ??
+    fallbackUsername ??
+    null;
+
+  if (slug && ownerUsername) {
+    return `/@${ownerUsername}/${slug}`;
+  }
+
+  if (typeof project.id === 'number') {
+    return `/project/${project.id}`;
+  }
+
+  if (typeof project.projectId === 'number') {
+    return `/project/${project.projectId}`;
+  }
+
+  return '/projects';
 }

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -109,13 +109,13 @@ export function getProjectUrl(project: ProjectLike, fallbackUsername?: string | 
     return `/@${ownerUsername}/${slug}`;
   }
 
-  if (typeof project.id === 'number') {
-    return `/project/${project.id}`;
+  // Prefer `id` over `projectId` if both are present
+  const projectNumericId = 
+    typeof project.id === 'number' ? project.id :
+    typeof project.projectId === 'number' ? project.projectId :
+    null;
+  if (projectNumericId !== null) {
+    return `/project/${projectNumericId}`;
   }
-
-  if (typeof project.projectId === 'number') {
-    return `/project/${project.projectId}`;
-  }
-
   return '/projects';
 }

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -34,6 +34,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { getProjectUrl } from '@/lib/utils';
 
 
 // Icon mapping for quick actions
@@ -159,14 +160,10 @@ export default function Dashboard() {
         // Store prompt in sessionStorage for the AI agent
         window.sessionStorage.setItem(`agent-prompt-${project.id}`, aiPrompt);
         
-        // Ensure we have the owner username and slug
-        const ownerUsername = project.owner?.username || user?.username || 'admin';
-        // Use slug if available, otherwise fallback to name (which should be slugified)
-        const projectSlug = project.slug || project.name.toLowerCase().replace(/[^a-z0-9]/g, '-');
-        const projectUrl = `/@${ownerUsername}/${projectSlug}`;
+        const projectUrl = getProjectUrl(project, user?.username);
         console.log(`Navigating to: ${projectUrl}`);
         console.log('Project has slug:', project.slug);
-        
+
         // Add a small delay to ensure project is fully created and indexed
         setTimeout(() => {
           // Use window.location for full page reload to ensure auth state is fresh
@@ -211,11 +208,9 @@ export default function Dashboard() {
         // Store prompt in sessionStorage for the AI agent
         window.sessionStorage.setItem(`agent-prompt-${project.id}`, prompt);
         
-        // Ensure we have the owner username
-        const ownerUsername = project.owner?.username || user?.username || 'admin';
-        const projectUrl = `/@${ownerUsername}/${project.slug}`;
+        const projectUrl = getProjectUrl(project, user?.username);
         console.log(`Navigating to: ${projectUrl}`);
-        
+
         // Add a small delay to ensure project is fully created and indexed
         setTimeout(() => {
           // Use window.location for full page reload to ensure auth state is fresh
@@ -390,9 +385,8 @@ export default function Dashboard() {
                   key={project.id}
                   className="group bg-[var(--ecode-surface)] border border-[var(--ecode-border)] hover:border-[var(--ecode-border-hover)] transition-colors cursor-pointer rounded-lg p-4"
                   onClick={() => {
-                    // Navigate to the proper Replit-style URL format
-                    const ownerUsername = project.owner?.username || user?.username || 'admin';
-                    const projectUrl = project.slug ? `/@${ownerUsername}/${project.slug}` : `/project/${project.id}`;
+                    const ownerUsername = project.owner?.username || user?.username;
+                    const projectUrl = getProjectUrl(project, ownerUsername);
                     navigate(projectUrl);
                   }}
                 >
@@ -428,8 +422,8 @@ export default function Dashboard() {
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
                           <DropdownMenuItem onClick={() => {
-                            const ownerUsername = project.owner?.username || user?.username || 'admin';
-                            const projectUrl = project.slug ? `/@${ownerUsername}/${project.slug}` : `/project/${project.id}`;
+                            const ownerUsername = project.owner?.username || user?.username;
+                            const projectUrl = getProjectUrl(project, ownerUsername);
                             navigate(projectUrl);
                           }}>
                             <ExternalLink className="h-4 w-4 mr-2" />

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -44,6 +44,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Input } from "@/components/ui/input";
 import { ECodeLoading } from '@/components/ECodeLoading';
 import { AuthModal } from '@/components/AuthModal';
+import { getProjectUrl } from '@/lib/utils';
 
 export default function Home() {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
@@ -81,8 +82,7 @@ export default function Home() {
       
       // Add a small delay to ensure project is fully created and indexed
       setTimeout(() => {
-        // Use window.location for full page reload to ensure auth state is fresh
-        const projectUrl = `/@${user?.username || 'admin'}/${data.slug}`;
+        const projectUrl = getProjectUrl(data, user?.username);
         console.log(`Navigating to: ${projectUrl}`);
         window.location.href = projectUrl;
       }, 500);
@@ -243,10 +243,10 @@ export default function Home() {
               displayMode === "grid" ? (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
                   {sortedProjects.map((project) => (
-                    <Card 
-                      key={project.id} 
+                    <Card
+                      key={project.id}
                       className="bg-card border border-border hover:border-primary transition-colors cursor-pointer"
-                      onClick={() => navigate(`/@${user?.username || 'admin'}/${project.slug}`)}
+                      onClick={() => navigate(getProjectUrl(project, user?.username))}
                     >
                       <CardHeader className="pb-2">
                         <CardTitle className="flex items-center justify-between text-lg">
@@ -319,10 +319,10 @@ export default function Home() {
               ) : (
                 <div className="space-y-2">
                   {sortedProjects.map((project) => (
-                    <div 
+                    <div
                       key={project.id}
                       className="flex items-center p-3 border rounded-md hover:bg-accent cursor-pointer"
-                      onClick={() => navigate(`/@${user?.username || 'admin'}/${project.slug}`)}
+                      onClick={() => navigate(getProjectUrl(project, user?.username))}
                     >
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">

--- a/client/src/pages/Landing.tsx
+++ b/client/src/pages/Landing.tsx
@@ -21,6 +21,7 @@ import { AnimatedPlatformDemo } from '@/components/AnimatedPlatformDemo';
 import { useToast } from '@/hooks/use-toast';
 import { useQuery } from '@tanstack/react-query';
 import { Spinner } from '@/components/ui/spinner';
+import { getProjectUrl } from '@/lib/utils';
 import { 
   SiPython, SiJavascript, SiHtml5, SiCss3,
   SiTypescript, SiGo, SiReact, SiNodedotjs, SiSpring,
@@ -161,11 +162,9 @@ export default function Landing() {
           // Store prompt in sessionStorage for the AI agent
           window.sessionStorage.setItem(`agent-prompt-${project.id}`, description);
           
-          // Ensure we have the owner username
-          const ownerUsername = project.owner?.username || user?.username || 'admin';
-          const projectUrl = `/@${ownerUsername}/${project.slug}`;
+          const projectUrl = getProjectUrl(project, user?.username);
           console.log(`Navigating to: ${projectUrl}`);
-          
+
           // Add a small delay to ensure project is fully created and indexed
           setTimeout(() => {
             // Use window.location for full page reload to ensure auth state is fresh

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -9,6 +9,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/use-auth';
 import { Loader2, Code } from 'lucide-react';
 import { Link } from 'wouter';
+import { getProjectUrl } from '@/lib/utils';
 
 export default function Login() {
   const [, navigate] = useLocation();
@@ -38,7 +39,8 @@ export default function Login() {
         const project = await response.json();
         // Store prompt in sessionStorage for the AI agent
         window.sessionStorage.setItem(`agent-prompt-${project.id}`, description);
-        navigate(`/@${project.owner?.username || 'user'}/${project.slug}?agent=true&prompt=${encodeURIComponent(description)}`);
+        const projectUrl = getProjectUrl(project, project.owner?.username);
+        navigate(`${projectUrl}?agent=true&prompt=${encodeURIComponent(description)}`);
       }
     } catch (error) {
       console.error('Failed to create project:', error);

--- a/client/src/pages/ProjectsPage.tsx
+++ b/client/src/pages/ProjectsPage.tsx
@@ -9,7 +9,7 @@ import { useAuth } from '@/hooks/use-auth';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { cn } from '@/lib/utils';
+import { cn, getProjectUrl } from '@/lib/utils';
 
 // UI Components
 import { Button } from '@/components/ui/button';
@@ -264,12 +264,8 @@ const ProjectsPage = () => {
         title: "Great! Your project is ready",
         description: `"${project.name}" is all set up. Let's start creating!`,
       });
-      // Navigate to the new project using Replit-style URL
-      if (user?.username && project.slug) {
-        setLocation(`/@${user.username}/${project.slug}`);
-      } else {
-        setLocation(`/project/${project.id}`);
-      }
+      const projectUrl = getProjectUrl(project, user?.username);
+      setLocation(projectUrl);
     },
     onError: (error: Error) => {
       toast({
@@ -494,11 +490,8 @@ const ProjectsPage = () => {
   const handleProjectClick = (project: Project) => {
     trackViewMutation.mutate(project.id);
     // Use new Replit-style URL format if we have owner and slug
-    if (project.owner?.username && project.slug) {
-      setLocation(`/@${project.owner.username}/${project.slug}`);
-    } else {
-      setLocation(`/project/${project.id}`);
-    }
+    const projectUrl = getProjectUrl(project, project.owner?.username);
+    setLocation(projectUrl);
   };
 
   // Function to get language icon


### PR DESCRIPTION
## Summary
- add a shared `getProjectUrl` helper to build canonical project URLs with an ID fallback
- update project creation and navigation flows to use the helper so new workspaces open reliably
- update quick navigation entry points (spotlight, templates, dashboards) to reuse the helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f476aca7c08320a07046072d16d468