### PR TITLE
Revamp marketing UI and stabilize navigation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -59,6 +59,8 @@ const ContactSales = lazy(() => import("@/pages/ContactSales"));
 const Terms = lazy(() => import("@/pages/Terms"));
 const Privacy = lazy(() => import("@/pages/Privacy"));
 const Status = lazy(() => import("@/pages/Status"));
+const Forum = lazy(() => import("@/pages/Forum"));
+const ComparePage = lazy(() => import("@/pages/compare/ComparePage"));
 
 const MobileAdmin = lazy(() => import("@/pages/mobile"));
 const AI = lazy(() => import("@/pages/AI"));
@@ -117,6 +119,8 @@ const SecretManagement = lazy(() => import("@/pages/SecretManagement"));
 const UsageAlerts = lazy(() => import("@/pages/UsageAlerts"));
 // Newsletter pages
 const NewsletterConfirmed = lazy(() => import("@/pages/NewsletterConfirmed"));
+const NewsletterConfirm = lazy(() => import("@/pages/NewsletterConfirm"));
+const NewsletterUnsubscribe = lazy(() => import("@/pages/NewsletterUnsubscribe"));
 
 // Legal pages
 const DPA = lazy(() => import("@/pages/DPA"));
@@ -137,6 +141,7 @@ const WebsiteBuilder = lazy(() => import("@/pages/solutions/WebsiteBuilder"));
 const GameBuilder = lazy(() => import("@/pages/solutions/GameBuilder"));
 const DashboardBuilder = lazy(() => import("@/pages/solutions/DashboardBuilder"));
 const ChatbotBuilder = lazy(() => import("@/pages/solutions/ChatbotBuilder"));
+const InternalAIBuilder = lazy(() => import("@/pages/solutions/InternalAIBuilder"));
 const PreviewWithDevTools = lazy(() => import("@/pages/PreviewWithDevTools"));
 
 const CodeGeneration = lazy(() => import("@/pages/CodeGeneration"));
@@ -156,6 +161,28 @@ import { CommandPalette } from "@/components/CommandPalette";
 import { KeyboardShortcuts } from "@/components/KeyboardShortcuts";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { ApplicationIDEWrapper } from "@/components/ApplicationIDEWrapper";
+const FeaturePlaceholder = lazy(() => import("@/pages/FeaturePlaceholder"));
+
+const placeholderRoutes = [
+  { path: "/assistant", feature: "assistant" },
+  { path: "/database", feature: "database" },
+  { path: "/console", feature: "console" },
+  { path: "/authentication", feature: "authentication" },
+  { path: "/preview", feature: "preview" },
+  { path: "/agent", feature: "agent" },
+  { path: "/code-search", feature: "code-search" },
+  { path: "/packages", feature: "packages" },
+  { path: "/extensions", feature: "extensions" },
+  { path: "/integrations", feature: "integrations" },
+  { path: "/networking", feature: "networking" },
+  { path: "/problems", feature: "problems" },
+  { path: "/kv-store", feature: "kv-store" },
+  { path: "/shell", feature: "shell" },
+  { path: "/threads", feature: "threads" },
+  { path: "/vnc", feature: "vnc" },
+  { path: "/referrals", feature: "referrals" },
+  { path: "/teams/new", feature: "teams/new" },
+];
 
 // Loading fallback component
 function PageLoader() {
@@ -172,6 +199,7 @@ function AppContent() {
           <Toaster />
           <SpotlightSearch />
           <CommandPalette />
+          <KeyboardShortcuts />
 
           <Suspense fallback={<PageLoader />}>
             <Switch>
@@ -197,6 +225,8 @@ function AppContent() {
           <Route path="/commercial-agreement" component={CommercialAgreement} />
           <Route path="/report-abuse" component={ReportAbuse} />
           <Route path="/status" component={Status} />
+          <Route path="/forum" component={Forum} />
+          <Route path="/compare/:slug" component={ComparePage} />
 
           <Route path="/marketing/bounties" component={MarketingBounties} />
           <Route path="/marketing/deployments" component={PublicDeploymentsPage} />
@@ -208,7 +238,8 @@ function AppContent() {
           <Route path="/solutions/game-builder" component={GameBuilder} />
           <Route path="/solutions/dashboard-builder" component={DashboardBuilder} />
           <Route path="/solutions/chatbot-builder" component={ChatbotBuilder} />
-          
+          <Route path="/solutions/internal-ai-builder" component={InternalAIBuilder} />
+
           <Route path="/mobile" component={MobileAdmin} />
           <Route path="/ai" component={AI} />
           <Route path="/ai-agent" component={AIAgent} />
@@ -257,6 +288,8 @@ function AppContent() {
           <Route path="/git" component={Git} />
           {/* Newsletter pages */}
           <Route path="/newsletter-confirmed" component={NewsletterConfirmed} />
+          <Route path="/newsletter/confirm" component={NewsletterConfirm} />
+          <Route path="/newsletter/unsubscribe" component={NewsletterUnsubscribe} />
           {/* Shared snippet page */}
           <Route path="/share/:shareId" component={SharedSnippet} />
 
@@ -275,6 +308,19 @@ function AppContent() {
               <Teams />
             </ReplitLayout>
           )} />
+          {placeholderRoutes
+            .filter((route) => route.path.startsWith("/teams"))
+            .map((route) => (
+              <ProtectedRoute
+                key={route.path}
+                path={route.path}
+                component={() => (
+                  <ReplitLayout showSidebar={false}>
+                    <FeaturePlaceholder featureKey={route.feature} />
+                  </ReplitLayout>
+                )}
+              />
+            ))}
           <ProtectedRoute path="/teams/:id" component={() => (
             <ReplitLayout showSidebar={false}>
               <TeamPage />
@@ -361,6 +407,19 @@ function AppContent() {
               <Notifications />
             </ReplitLayout>
           )} />
+          {placeholderRoutes
+            .filter((route) => !route.path.startsWith("/teams"))
+            .map((route) => (
+              <ProtectedRoute
+                key={route.path}
+                path={route.path}
+                component={() => (
+                  <ReplitLayout showSidebar={false}>
+                    <FeaturePlaceholder featureKey={route.feature} />
+                  </ReplitLayout>
+                )}
+              />
+            ))}
           <ProtectedRoute path="/profile/:username?" component={() => (
             <ReplitLayout>
               <Profile />

--- a/client/src/components/ReplitAgent.tsx
+++ b/client/src/components/ReplitAgent.tsx
@@ -1620,7 +1620,7 @@ What would you like me to build?`,
                   variant="ghost"
                   size="sm"
                   className="h-8 w-8 p-0"
-                  onClick={() => window.location.href = '/billing'}
+                  onClick={() => window.location.href = '/subscribe'}
                 >
                   <DollarSign className="h-4 w-4" />
                 </Button>

--- a/client/src/components/layout/MarketingLayout.tsx
+++ b/client/src/components/layout/MarketingLayout.tsx
@@ -1,0 +1,24 @@
+import { PropsWithChildren } from "react";
+import { cn } from "@/lib/utils";
+import { PublicNavbar } from "./PublicNavbar";
+import { PublicFooter } from "./PublicFooter";
+
+interface MarketingLayoutProps extends PropsWithChildren {
+  className?: string;
+}
+
+export function MarketingLayout({ children, className }: MarketingLayoutProps) {
+  return (
+    <div className="min-h-screen flex flex-col bg-marketing-surface text-foreground">
+      <div className="relative">
+        <div className="marketing-backdrop" aria-hidden />
+        <PublicNavbar />
+      </div>
+      <main className={cn("flex-1 relative z-10", className)}>
+        <div className="marketing-gradient" aria-hidden />
+        <div className="relative z-10 pb-16">{children}</div>
+      </main>
+      <PublicFooter />
+    </div>
+  );
+}

--- a/client/src/components/layout/PublicFooter.tsx
+++ b/client/src/components/layout/PublicFooter.tsx
@@ -1,33 +1,41 @@
 // @ts-nocheck
 import { Link } from 'wouter';
-import { 
-  Twitter, Github, Youtube, Linkedin, Instagram,
-  Globe, Code, Users, BookOpen, Shield, HelpCircle
+import {
+  Twitter,
+  Github,
+  Youtube,
+  Linkedin,
+  Instagram,
+  Sparkles,
+  ShieldCheck,
+  Globe2,
+  ArrowUpRight,
 } from 'lucide-react';
 import { ECodeLogo } from '@/components/ECodeLogo';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 
 export function PublicFooter() {
   const footerLinks = {
     product: [
+      { label: 'AI Agent', href: '/ai-agent' },
       { label: 'IDE', href: '/features' },
       { label: 'Multiplayer', href: '/features#multiplayer' },
       { label: 'Mobile App', href: '/mobile' },
-      { label: 'Teams', href: '/teams' },
-      { label: 'Deployments', href: '/deployments' },
+      { label: 'Teams', href: '/marketing/teams' },
+      { label: 'Deployments', href: '/marketing/deployments' },
       { label: 'Pricing', href: '/pricing' },
-      { label: 'Bounties', href: '/bounties' },
-      { label: 'AI', href: '/ai' },
-      { label: 'Templates', href: '/templates' },
+      { label: 'Bounties', href: '/marketing/bounties' },
+      { label: 'AI Platform', href: '/ai' },
     ],
     resources: [
       { label: 'Docs', href: '/docs' },
       { label: 'Blog', href: '/blog' },
       { label: 'Community', href: '/community' },
-      { label: 'Forum', href: '/forum' },
+      { label: 'Templates', href: '/templates' },
+      { label: 'Languages', href: '/templates/languages' },
       { label: 'Status', href: '/status' },
-      { label: 'Import from GitHub', href: '/github-import' },
-      { label: 'E-Code Desktop App', href: '/desktop' },
-      { label: 'Programming Languages', href: '/languages' },
+      { label: 'Forum', href: '/forum' },
     ],
     company: [
       { label: 'About', href: '/about' },
@@ -37,12 +45,13 @@ export function PublicFooter() {
       { label: 'Contact Sales', href: '/contact-sales' },
     ],
     legal: [
-      { label: 'Terms of Service', href: '/terms' },
-      { label: 'Privacy Policy', href: '/privacy' },
+      { label: 'Terms', href: '/terms' },
+      { label: 'Privacy', href: '/privacy' },
       { label: 'Subprocessors', href: '/subprocessors' },
       { label: 'DPA', href: '/dpa' },
       { label: 'US Student DPA', href: '/student-dpa' },
       { label: 'Security', href: '/security' },
+      { label: 'Report Abuse', href: '/report-abuse' },
     ],
     compare: [
       { label: 'E-Code vs GitHub Codespaces', href: '/compare/github-codespaces' },
@@ -51,7 +60,7 @@ export function PublicFooter() {
       { label: 'E-Code vs CodeSandbox', href: '/compare/codesandbox' },
       { label: 'E-Code vs AWS Cloud9', href: '/compare/aws-cloud9' },
     ],
-  };
+  } as const;
 
   const socialLinks = [
     { icon: Twitter, href: 'https://twitter.com/ecode', label: 'Twitter' },
@@ -62,164 +71,167 @@ export function PublicFooter() {
   ];
 
   return (
-    <footer className="bg-background border-t mt-auto">
-      <div className="container-responsive py-12 sm:py-16">
-        {/* Main Footer Content */}
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-8 mb-12">
-          {/* Product */}
-          <div>
-            <h3 className="font-semibold mb-4 text-foreground">Product</h3>
-            <ul className="space-y-2">
-              {footerLinks.product.map((link) => (
-                <li key={link.href}>
-                  <Link 
-                    href={link.href}
-                    className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    {link.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {/* Resources */}
-          <div>
-            <h3 className="font-semibold mb-4 text-foreground">Resources</h3>
-            <ul className="space-y-2">
-              {footerLinks.resources.map((link) => (
-                <li key={link.href}>
-                  <Link 
-                    href={link.href}
-                    className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    {link.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {/* Company */}
-          <div>
-            <h3 className="font-semibold mb-4 text-foreground">Company</h3>
-            <ul className="space-y-2">
-              {footerLinks.company.map((link) => (
-                <li key={link.href}>
-                  <Link 
-                    href={link.href}
-                    className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    {link.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {/* Legal */}
-          <div>
-            <h3 className="font-semibold mb-4 text-foreground">Legal</h3>
-            <ul className="space-y-2">
-              {footerLinks.legal.map((link) => (
-                <li key={link.href}>
-                  <Link 
-                    href={link.href}
-                    className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    {link.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {/* Compare */}
-          <div className="col-span-2 lg:col-span-1">
-            <h3 className="font-semibold mb-4 text-foreground">Compare</h3>
-            <ul className="space-y-2">
-              {footerLinks.compare.map((link) => (
-                <li key={link.href}>
-                  <Link 
-                    href={link.href}
-                    className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    {link.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {/* Mobile App */}
-          <div className="col-span-2 md:col-span-3 lg:col-span-1">
-            <h3 className="font-semibold mb-4 text-foreground">Mobile App</h3>
-            <div className="space-y-3">
-              <a 
-                href="https://apps.apple.com/app/e-code" 
-                target="_blank" 
-                rel="noopener noreferrer"
-                className="inline-block"
+    <footer className="relative border-t border-white/10 bg-slate-950/90 text-slate-200">
+      <div className="absolute inset-0 marketing-gradient" aria-hidden />
+      <div className="absolute inset-0 marketing-grid opacity-60" aria-hidden />
+      <div className="relative container-responsive py-16">
+        <div className="grid gap-12 lg:grid-cols-[1.2fr_2fr]">
+          <div className="space-y-6">
+            <Badge className="bg-white/10 text-white border-white/20">
+              <Sparkles className="mr-2 h-3 w-3" />
+              Built for Fortune 500
+            </Badge>
+            <h3 className="text-3xl sm:text-4xl font-semibold text-white tracking-tight">
+              The future of enterprise software development
+            </h3>
+            <p className="text-sm sm:text-base text-slate-300 leading-relaxed max-w-lg">
+              E-Code combines secure cloud workspaces, intelligent automation, and enterprise controls so your teams can ship faster across every device.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Button
+                className="bg-gradient-to-r from-sky-400 via-blue-500 to-indigo-500 text-white shadow-lg shadow-blue-500/25"
+                onClick={() => (window.location.href = '/contact-sales')}
               >
-                <img 
-                  src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-app-store.svg" 
-                  alt="Download on the App Store"
-                  className="h-10"
-                />
-              </a>
-              <a 
-                href="https://play.google.com/store/apps/details?id=com.e-code.app" 
-                target="_blank" 
-                rel="noopener noreferrer"
-                className="inline-block"
+                Talk to sales
+                <ArrowUpRight className="ml-2 h-4 w-4" />
+              </Button>
+              <Button
+                variant="outline"
+                className="border-white/20 text-slate-100 hover:text-white"
+                onClick={() => (window.location.href = '/register')}
               >
-                <img 
-                  src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" 
-                  alt="Get it on Google Play"
-                  className="h-10"
-                />
-              </a>
+                Start building
+              </Button>
+            </div>
+            <div className="grid grid-cols-2 gap-4 pt-4 text-sm text-slate-300">
+              <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+                <p className="text-xs uppercase tracking-widest text-slate-400">Global uptime</p>
+                <p className="mt-2 text-2xl font-semibold text-white">99.99%</p>
+              </div>
+              <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+                <p className="text-xs uppercase tracking-widest text-slate-400">Enterprise teams</p>
+                <p className="mt-2 text-2xl font-semibold text-white">4,500+</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid gap-10 sm:grid-cols-2 lg:grid-cols-4">
+            <div>
+              <h4 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">Product</h4>
+              <ul className="mt-4 space-y-2 text-sm">
+                {footerLinks.product.map((link) => (
+                  <li key={link.href}>
+                    <Link href={link.href} className="text-slate-300 transition hover:text-white">
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h4 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">Resources</h4>
+              <ul className="mt-4 space-y-2 text-sm">
+                {footerLinks.resources.map((link) => (
+                  <li key={link.href}>
+                    <Link href={link.href} className="text-slate-300 transition hover:text-white">
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h4 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">Company</h4>
+              <ul className="mt-4 space-y-2 text-sm">
+                {footerLinks.company.map((link) => (
+                  <li key={link.href}>
+                    <Link href={link.href} className="text-slate-300 transition hover:text-white">
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h4 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">Legal</h4>
+              <ul className="mt-4 space-y-2 text-sm">
+                {footerLinks.legal.map((link) => (
+                  <li key={link.href}>
+                    <Link href={link.href} className="text-slate-300 transition hover:text-white">
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="sm:col-span-2 lg:col-span-4">
+              <div className="mt-6 rounded-2xl border border-white/10 bg-white/5 p-6">
+                <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                  <div>
+                    <p className="text-sm font-semibold text-white">Compare platforms</p>
+                    <p className="text-xs text-slate-300">See how E-Code stacks up against other development clouds.</p>
+                  </div>
+                  <div className="flex flex-wrap gap-3">
+                    {footerLinks.compare.map((link) => (
+                      <Link
+                        key={link.href}
+                        href={link.href}
+                        className="rounded-full border border-white/15 px-3 py-1.5 text-xs text-slate-200 transition hover:border-white/50 hover:text-white"
+                      >
+                        {link.label}
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
 
-        {/* Bottom Section */}
-        <div className="pt-8 border-t flex flex-col sm:flex-row items-center justify-between gap-4">
-          {/* Logo and Copyright */}
-          <div className="flex items-center gap-4">
+        <div className="mt-16 grid gap-8 border-t border-white/10 pt-10 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="flex items-center gap-3 text-sm text-slate-300">
+            <ShieldCheck className="h-5 w-5 text-emerald-300" />
+            SOC2 Type II, ISO 27001, GDPR & HIPAA ready.
+          </div>
+          <div className="flex items-center gap-3 text-sm text-slate-300">
+            <Globe2 className="h-5 w-5 text-sky-300" />
+            18 global regions with enterprise data residency.
+          </div>
+          <div className="flex items-center gap-3 text-sm text-slate-300">
+            <Sparkles className="h-5 w-5 text-indigo-300" />
+            AI governance, policy controls, and audit logging.
+          </div>
+          <div className="flex flex-wrap items-center gap-4">
+            {socialLinks.map((social) => (
+              <a
+                key={social.label}
+                href={social.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-slate-200 transition hover:border-white/40 hover:text-white"
+              >
+                <social.icon className="h-5 w-5" />
+              </a>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-12 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 text-xs text-slate-400">
+          <div className="flex items-center gap-3">
             <Link href="/">
               <div className="cursor-pointer">
-                <ECodeLogo size="sm" />
+                <ECodeLogo size="xs" />
               </div>
             </Link>
-            <span className="text-sm text-muted-foreground">
-              © {new Date().getFullYear()} E-Code Inc. All rights reserved.
-            </span>
-            <Link 
-              href="/newsletter/unsubscribe"
-              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Unsubscribe
-            </Link>
+            <span>© {new Date().getFullYear()} E-Code Inc. All rights reserved.</span>
           </div>
-
-          {/* Social Links */}
           <div className="flex items-center gap-4">
-            {socialLinks.map((social) => {
-              const Icon = social.icon;
-              return (
-                <a
-                  key={social.label}
-                  href={social.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                  aria-label={social.label}
-                >
-                  <Icon className="h-5 w-5" />
-                </a>
-              );
-            })}
+            <Link href="/newsletter/unsubscribe" className="hover:text-white">
+              Email preferences
+            </Link>
+            <Link href="/newsletter-confirmed" className="hover:text-white">
+              Newsletter
+            </Link>
           </div>
         </div>
       </div>

--- a/client/src/components/layout/PublicNavbar.tsx
+++ b/client/src/components/layout/PublicNavbar.tsx
@@ -11,487 +11,320 @@ import {
   NavigationMenuTrigger,
 } from '@/components/ui/navigation-menu';
 import { Sheet, SheetContent, SheetTrigger, SheetHeader, SheetTitle } from '@/components/ui/sheet';
-import { 
-  Menu, X, ChevronDown, Code, ChevronRight, Sparkles, 
-  Terminal, Users, Smartphone, Monitor, Brain, Rocket, 
-  DollarSign, FileText, BookOpen, MessageSquare, Globe,
-  Briefcase, Building, Newspaper, Handshake, Star,
-  Search, Settings, LogIn
-} from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { ThemeSwitcher } from '@/components/ThemeSwitcher';
-import { ECodeLogo } from '@/components/ECodeLogo';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Separator } from '@/components/ui/separator';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
+import {
+  Menu,
+  X,
+  ChevronRight,
+  Sparkles,
+  ArrowUpRight,
+  Search,
+  LogIn,
+} from 'lucide-react';
+import { ThemeSwitcher } from '@/components/ThemeSwitcher';
+import { ECodeLogo } from '@/components/ECodeLogo';
 import './MobileNavigation.css';
 
 export function PublicNavbar() {
-  const [location, navigate] = useLocation();
+  const [, navigate] = useLocation();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   const productItems = [
-    { title: 'AI Agent', href: '/ai-agent', description: 'Build apps with AI in seconds' },
-    { title: 'IDE', href: '/features', description: 'Code in your browser' },
-    { title: 'Multiplayer', href: '/features#multiplayer', description: 'Code with your team' },
-    { title: 'Mobile App', href: '/mobile', description: 'Code on the go' },
-    { title: 'Desktop App', href: '/desktop', description: 'Code offline' },
-    { title: 'AI', href: '/ai', description: 'AI-powered coding' },
-    { title: 'Deployments', href: '/marketing/deployments', description: 'Global cloud hosting platform' },
-    { title: 'Bounties', href: '/marketing/bounties', description: 'Developer marketplace for earning' },
-    { title: 'Teams', href: '/marketing/teams', description: 'Collaborate and scale together' },
+    { title: 'AI Agent', href: '/ai-agent', description: 'Build production-ready apps with natural language prompts.' },
+    { title: 'Browser IDE', href: '/features', description: 'Enterprise-grade development workspace built for teams.' },
+    { title: 'Multiplayer', href: '/features#multiplayer', description: 'Live collaboration, pair programming, and shared presence.' },
+    { title: 'Mobile App', href: '/mobile', description: 'Ship from anywhere with a fully-featured mobile IDE.' },
+    { title: 'Desktop App', href: '/desktop', description: 'Optimized offline workflow with secure device sync.' },
+    { title: 'AI Platform', href: '/ai', description: 'Governance, observability, and orchestration for AI workloads.' },
+    { title: 'Deployments', href: '/marketing/deployments', description: 'Global edge infrastructure with Fortune 500 reliability.' },
+    { title: 'Bounties', href: '/marketing/bounties', description: 'Activate an on-demand developer network to accelerate delivery.' },
+    { title: 'Teams', href: '/marketing/teams', description: 'Enterprise controls, compliance, and insights for large orgs.' },
   ];
 
   const solutionsItems = [
-    { title: 'App Builder', href: '/solutions/app-builder', description: 'Build full-stack applications with AI' },
-    { title: 'Website Builder', href: '/solutions/website-builder', description: 'Create stunning websites instantly' },
-    { title: 'Game Builder', href: '/solutions/game-builder', description: 'Design and code games with AI' },
-    { title: 'Dashboard Builder', href: '/solutions/dashboard-builder', description: 'Build data visualizations and dashboards' },
-    { title: 'Chatbot / AI Agent Builder', href: '/solutions/chatbot-builder', description: 'Create intelligent conversational agents' },
-    { title: 'AI Agent Internal Builder', href: '/solutions/internal-ai-builder', description: 'Deploy AI agents for your team' },
+    { title: 'App Builder', href: '/solutions/app-builder', description: 'Rapidly prototype and deploy full-stack applications.' },
+    { title: 'Website Builder', href: '/solutions/website-builder', description: 'Create polished marketing sites with zero setup.' },
+    { title: 'Game Builder', href: '/solutions/game-builder', description: 'Design and launch interactive experiences powered by AI.' },
+    { title: 'Dashboard Builder', href: '/solutions/dashboard-builder', description: 'Data-rich dashboards with real-time collaboration.' },
+    { title: 'Chatbot / AI Agent Builder', href: '/solutions/chatbot-builder', description: 'Deploy conversational assistants across your organization.' },
+    { title: 'Internal AI Builder', href: '/solutions/internal-ai-builder', description: 'Bring private AI agents to every team safely and securely.' },
   ];
 
   const resourcesItems = [
-    { title: 'Documentation', href: '/docs', description: 'Learn how to use E-Code' },
-    { title: 'Blog', href: '/blog', description: 'News and updates' },
-    { title: 'Community', href: '/community', description: 'Connect with developers' },
-    { title: 'Templates', href: '/templates', description: 'Start from a template' },
-    { title: 'Languages', href: '/templates/languages', description: '40+ supported languages' },
-    { title: 'Status', href: '/status', description: 'Service uptime' },
-    { title: 'Forum', href: '/forum', description: 'Get help' },
+    { title: 'Documentation', href: '/docs', description: 'Get started quickly with step-by-step guides.' },
+    { title: 'Blog', href: '/blog', description: 'Stories on shipping software at global scale.' },
+    { title: 'Community', href: '/community', description: 'Connect with builders and share best practices.' },
+    { title: 'Templates', href: '/templates', description: 'Launch with curated, industry-specific templates.' },
+    { title: 'Languages', href: '/templates/languages', description: 'Build in 40+ languages without local installs.' },
+    { title: 'Status', href: '/status', description: 'Transparency around platform availability.' },
+    { title: 'Forum', href: '/forum', description: 'Get support from E-Code experts and peers.' },
   ];
 
   const companyItems = [
-    { title: 'About', href: '/about', description: 'Our mission' },
-    { title: 'Careers', href: '/careers', description: 'Join our team' },
-    { title: 'Press', href: '/press', description: 'News coverage' },
-    { title: 'Partners', href: '/partners', description: 'Work with us' },
+    { title: 'About', href: '/about', description: 'Learn about our mission and leadership team.' },
+    { title: 'Careers', href: '/careers', description: 'Join a distributed team building the future of software.' },
+    { title: 'Press', href: '/press', description: 'Press releases, media kit, and recent coverage.' },
+    { title: 'Partners', href: '/partners', description: 'Strategic alliances and solution partners.' },
   ];
 
+  const desktopNav = (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Product</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="grid w-[480px] gap-3 p-4 md:w-[520px] md:grid-cols-2 lg:w-[640px]">
+              {productItems.map((item) => (
+                <li key={item.title}>
+                  <Link
+                    href={item.href}
+                    className="block rounded-xl border border-white/10 bg-white/[0.02] p-4 transition-all duration-200 hover:-translate-y-1 hover:bg-white/[0.06] hover:shadow-lg hover:shadow-sky-500/10"
+                  >
+                    <div className="text-sm font-semibold text-white flex items-center gap-2">
+                      <Sparkles className="h-4 w-4 text-sky-300" />
+                      {item.title}
+                    </div>
+                    <p className="mt-2 text-sm text-slate-300 leading-relaxed">
+                      {item.description}
+                    </p>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Solutions</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="grid w-[480px] gap-3 p-4 md:w-[520px] md:grid-cols-2 lg:w-[640px]">
+              {solutionsItems.map((item) => (
+                <li key={item.title}>
+                  <Link
+                    href={item.href}
+                    className="block rounded-xl border border-white/10 bg-white/[0.02] p-4 transition-all duration-200 hover:-translate-y-1 hover:bg-white/[0.06] hover:shadow-lg hover:shadow-sky-500/10"
+                  >
+                    <div className="text-sm font-semibold text-white flex items-center gap-2">
+                      <ArrowUpRight className="h-4 w-4 text-indigo-300" />
+                      {item.title}
+                    </div>
+                    <p className="mt-2 text-sm text-slate-300 leading-relaxed">
+                      {item.description}
+                    </p>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Resources</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="grid w-[480px] gap-3 p-4 md:w-[520px] md:grid-cols-2 lg:w-[640px]">
+              {resourcesItems.map((item) => (
+                <li key={item.title}>
+                  <Link
+                    href={item.href}
+                    className="block rounded-xl border border-white/10 bg-white/[0.02] p-4 transition-all duration-200 hover:-translate-y-1 hover:bg-white/[0.06] hover:shadow-lg hover:shadow-sky-500/10"
+                  >
+                    <div className="text-sm font-semibold text-white flex items-center gap-2">
+                      <Search className="h-4 w-4 text-sky-300" />
+                      {item.title}
+                    </div>
+                    <p className="mt-2 text-sm text-slate-300 leading-relaxed">
+                      {item.description}
+                    </p>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Company</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="grid w-[360px] gap-3 p-4">
+              {companyItems.map((item) => (
+                <li key={item.title}>
+                  <Link
+                    href={item.href}
+                    className="block rounded-xl border border-white/10 bg-white/[0.02] p-4 transition-all duration-200 hover:-translate-y-1 hover:bg-white/[0.06] hover:shadow-lg hover:shadow-sky-500/10"
+                  >
+                    <div className="text-sm font-semibold text-white flex items-center gap-2">
+                      <ChevronRight className="h-4 w-4 text-indigo-300" />
+                      {item.title}
+                    </div>
+                    <p className="mt-2 text-sm text-slate-300 leading-relaxed">
+                      {item.description}
+                    </p>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+
+        <NavigationMenuItem>
+          <NavigationMenuLink
+            href="/pricing"
+            className="group inline-flex h-10 w-max items-center justify-center rounded-full border border-white/15 px-5 text-sm font-medium text-slate-200 transition-colors hover:border-white/40 hover:text-white"
+          >
+            Pricing
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+
+        <NavigationMenuItem>
+          <NavigationMenuLink
+            href="/team"
+            className="group inline-flex h-10 w-max items-center justify-center rounded-full border border-white/15 px-5 text-sm font-medium text-slate-200 transition-colors hover:border-white/40 hover:text-white"
+          >
+            Teams
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  );
+
+  const primaryCta = (
+    <Button
+      onClick={() => window.location.href = '/register'}
+      className="hidden sm:inline-flex bg-gradient-to-r from-sky-400 via-blue-500 to-indigo-500 text-white hover:from-sky-300 hover:via-blue-400 hover:to-indigo-400 shadow-lg shadow-blue-500/25"
+    >
+      Get started
+    </Button>
+  );
+
   return (
-    <nav className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="container-responsive">
-        <div className="flex h-16 items-center justify-between">
-          {/* Logo */}
-          <div className="flex items-center gap-6">
-            <Link href="/">
-              <div className="cursor-pointer">
-                <ECodeLogo size="sm" />
-              </div>
-            </Link>
-
-            {/* Desktop Navigation */}
-            <div className="hidden lg:block">
-              <NavigationMenu>
-                <NavigationMenuList>
-                  <NavigationMenuItem>
-                    <NavigationMenuTrigger>Product</NavigationMenuTrigger>
-                    <NavigationMenuContent>
-                      <ul className="grid w-[400px] gap-3 p-4 md:w-[500px] md:grid-cols-2 lg:w-[600px]">
-                        {productItems.map((item) => (
-                          <li key={item.title}>
-                            <Link href={item.href} className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground">
-                              <div className="text-sm font-medium leading-none">{item.title}</div>
-                              <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
-                                {item.description}
-                              </p>
-                            </Link>
-                          </li>
-                        ))}
-                      </ul>
-                    </NavigationMenuContent>
-                  </NavigationMenuItem>
-
-                  <NavigationMenuItem>
-                    <NavigationMenuTrigger>Solutions</NavigationMenuTrigger>
-                    <NavigationMenuContent>
-                      <ul className="grid w-[400px] gap-3 p-4 md:w-[500px] md:grid-cols-2 lg:w-[600px]">
-                        {solutionsItems.map((item) => (
-                          <li key={item.title}>
-                            <Link href={item.href} className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground">
-                              <div className="text-sm font-medium leading-none">{item.title}</div>
-                              <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
-                                {item.description}
-                              </p>
-                            </Link>
-                          </li>
-                        ))}
-                      </ul>
-                    </NavigationMenuContent>
-                  </NavigationMenuItem>
-
-                  <NavigationMenuItem>
-                    <NavigationMenuTrigger>Resources</NavigationMenuTrigger>
-                    <NavigationMenuContent>
-                      <ul className="grid w-[400px] gap-3 p-4 md:w-[500px] md:grid-cols-2 lg:w-[600px]">
-                        {resourcesItems.map((item) => (
-                          <li key={item.title}>
-                            <Link href={item.href} className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground">
-                              <div className="text-sm font-medium leading-none">{item.title}</div>
-                              <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
-                                {item.description}
-                              </p>
-                            </Link>
-                          </li>
-                        ))}
-                      </ul>
-                    </NavigationMenuContent>
-                  </NavigationMenuItem>
-
-                  <NavigationMenuItem>
-                    <NavigationMenuTrigger>Company</NavigationMenuTrigger>
-                    <NavigationMenuContent>
-                      <ul className="grid w-[400px] gap-3 p-4">
-                        {companyItems.map((item) => (
-                          <li key={item.title}>
-                            <Link href={item.href} className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground">
-                              <div className="text-sm font-medium leading-none">{item.title}</div>
-                              <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
-                                {item.description}
-                              </p>
-                            </Link>
-                          </li>
-                        ))}
-                      </ul>
-                    </NavigationMenuContent>
-                  </NavigationMenuItem>
-
-                  <NavigationMenuItem>
-                    <NavigationMenuLink 
-                      href="/pricing"
-                      className="group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50"
-                    >
-                      Pricing
-                    </NavigationMenuLink>
-                  </NavigationMenuItem>
-
-                  <NavigationMenuItem>
-                    <NavigationMenuLink 
-                      href="/team"
-                      className="group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50"
-                    >
-                      Teams
-                    </NavigationMenuLink>
-                  </NavigationMenuItem>
-                </NavigationMenuList>
-              </NavigationMenu>
-            </div>
+    <header className="sticky top-0 z-50 w-full">
+      <div className="hidden md:block border-b border-white/10 bg-gradient-to-r from-sky-500/20 via-indigo-500/20 to-purple-500/20">
+        <div className="container-responsive flex h-10 items-center justify-between text-xs text-slate-100">
+          <div className="flex items-center gap-3">
+            <Badge variant="secondary" className="bg-white/15 text-white border-white/25 uppercase tracking-[0.2em]">
+              NEW
+            </Badge>
+            <p className="font-medium">Introducing E-Code Enterprise Cloud with dedicated AI governance and auditability.</p>
           </div>
+          <button
+            className="inline-flex items-center gap-1 text-sky-200 hover:text-white transition-colors"
+            onClick={() => navigate('/contact-sales')}
+          >
+            Talk to an expert
+            <ChevronRight className="h-3 w-3" />
+          </button>
+        </div>
+      </div>
 
-          {/* Right side actions */}
-          <div className="flex items-center gap-4">
-            <ThemeSwitcher />
-            
-            <Button variant="ghost" onClick={() => window.location.href = '/login'}>
-              Log in
-            </Button>
-            
-            <Button onClick={() => window.location.href = '/register'} className="hidden sm:inline-flex">
-              Sign up
-            </Button>
+      <nav className="relative border-b border-white/10 bg-slate-950/75 backdrop-blur-xl">
+        <div className="absolute inset-0 marketing-grid" aria-hidden />
+        <div className="container-responsive relative">
+          <div className="flex h-16 items-center justify-between">
+            <div className="flex items-center gap-6">
+              <Link href="/">
+                <div className="cursor-pointer">
+                  <ECodeLogo size="sm" />
+                </div>
+              </Link>
 
-            {/* Mobile menu */}
-            <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
-              <SheetTrigger asChild>
-                <Button variant="ghost" size="icon" className="lg:hidden">
-                  <Menu className="h-5 w-5" />
-                </Button>
-              </SheetTrigger>
-              <SheetContent side="right" className="w-full sm:w-[480px] p-0 overflow-hidden sheet-content">
-                <div className="flex flex-col h-full">
-                  {/* Header */}
-                  <div className="mobile-nav-header px-6 py-4 border-b bg-background/95 backdrop-blur">
+              <div className="hidden lg:block text-slate-200">
+                {desktopNav}
+              </div>
+            </div>
+
+            <div className="flex items-center gap-4">
+              <ThemeSwitcher />
+              <Button
+                variant="ghost"
+                className="text-slate-200 hover:text-white"
+                onClick={() => window.location.href = '/login'}
+              >
+                <LogIn className="mr-2 h-4 w-4" />
+                Log in
+              </Button>
+              {primaryCta}
+
+              <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
+                <SheetTrigger asChild>
+                  <Button variant="ghost" size="icon" className="lg:hidden text-slate-100">
+                    <Menu className="h-5 w-5" />
+                  </Button>
+                </SheetTrigger>
+                <SheetContent side="right" className="w-full sm:w-[420px] bg-slate-950/95 text-slate-100 border-l border-white/10">
+                  <SheetHeader className="mb-6">
                     <div className="flex items-center justify-between">
                       <ECodeLogo size="sm" />
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8"
-                        onClick={() => setMobileMenuOpen(false)}
-                      >
+                      <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => setMobileMenuOpen(false)}>
                         <X className="h-4 w-4" />
                       </Button>
                     </div>
-                    {/* Search Bar */}
                     <div className="mt-4 relative">
-                      <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                      <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
                       <Input
-                        type="search"
-                        placeholder="Search E-Code..."
-                        className="pl-10 h-9 bg-muted/50 focus:bg-background"
+                        placeholder="Search documentation, templates, or people"
+                        className="pl-9 bg-white/5 border-white/10 text-slate-100 placeholder:text-slate-400"
                       />
                     </div>
+                  </SheetHeader>
+
+                  <div className="px-6">
+                    <Button
+                      className="w-full bg-gradient-to-r from-sky-400 via-blue-500 to-indigo-500 text-white shadow-lg shadow-blue-500/20"
+                      onClick={() => window.location.href = '/register'}
+                    >
+                      Create your account
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      className="mt-3 w-full border border-white/10 text-slate-200 hover:text-white"
+                      onClick={() => window.location.href = '/login'}
+                    >
+                      Sign in
+                    </Button>
                   </div>
 
-                  {/* Scrollable Content */}
-                  <ScrollArea className="flex-1">
-                    <div className="mobile-nav-content px-6 py-4 space-y-6">
-                      {/* Featured Actions */}
-                      <div className="mobile-nav-grid grid grid-cols-2 gap-3">
-                        <Button
-                          className="mobile-nav-item h-auto py-4 px-4 flex-col gap-2 bg-gradient-to-br from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700"
-                          onClick={() => {
-                            setMobileMenuOpen(false);
-                            navigate('/');
-                          }}
-                        >
-                          <Sparkles className="mobile-nav-icon h-5 w-5" />
-                          <span className="text-xs font-medium">Start Building</span>
-                        </Button>
-                        <Button
-                          variant="outline"
-                          className="mobile-nav-item h-auto py-4 px-4 flex-col gap-2"
-                          onClick={() => {
-                            setMobileMenuOpen(false);
-                            navigate('/templates');
-                          }}
-                        >
-                          <FileText className="mobile-nav-icon h-5 w-5" />
-                          <span className="text-xs font-medium">Browse Templates</span>
-                        </Button>
-                      </div>
-
-                      {/* Product Section */}
-                      <div>
-                        <div className="flex items-center justify-between mb-3">
-                          <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider">Product</h3>
-                          <Badge variant="secondary" className="text-[10px]">8 Features</Badge>
+                  <SheetTitle className="px-6 pt-8 pb-3 text-xs uppercase tracking-[0.3em] text-slate-400">
+                    Navigation
+                  </SheetTitle>
+                  <ScrollArea className="h-[55vh] px-6">
+                    <div className="space-y-8 pb-8">
+                      {[{ title: 'Product', items: productItems }, { title: 'Solutions', items: solutionsItems }, { title: 'Resources', items: resourcesItems }, { title: 'Company', items: companyItems }].map((section) => (
+                        <div key={section.title}>
+                          <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 mb-3">
+                            {section.title}
+                          </p>
+                          <div className="space-y-3">
+                            {section.items.map((item) => (
+                              <button
+                                key={item.title}
+                                onClick={() => {
+                                  setMobileMenuOpen(false);
+                                  setTimeout(() => navigate(item.href), 120);
+                                }}
+                                className="w-full text-left rounded-xl border border-white/10 bg-white/[0.04] p-4 transition hover:bg-white/[0.08]"
+                              >
+                                <div className="flex items-center justify-between">
+                                  <span className="text-sm font-semibold text-white">{item.title}</span>
+                                  <ChevronRight className="h-4 w-4 text-slate-400" />
+                                </div>
+                                <p className="mt-2 text-xs text-slate-300 leading-relaxed">
+                                  {item.description}
+                                </p>
+                              </button>
+                            ))}
+                          </div>
                         </div>
-                        <div className="space-y-1">
-                          {productItems.map((item) => {
-                            const icons: Record<string, any> = {
-                              'AI Agent': Brain,
-                              'IDE': Terminal,
-                              'Multiplayer': Users,
-                              'Mobile App': Smartphone,
-                              'Desktop App': Monitor,
-                              'AI': Sparkles,
-                              'Deployments': Rocket,
-                              'Bounties': DollarSign
-                            };
-                            const Icon = icons[item.title] || Code;
-                            
-                            return (
-                              <Link key={item.title} href={item.href}>
-                                <Button
-                                  variant="ghost"
-                                  className="mobile-nav-item w-full justify-start h-auto py-3 px-3 hover:bg-muted/80"
-                                  onClick={() => setMobileMenuOpen(false)}
-                                >
-                                  <div className="flex items-start gap-3 w-full">
-                                    <div className="rounded-lg bg-primary/10 p-2 mt-0.5">
-                                      <Icon className="mobile-nav-icon h-4 w-4 text-primary" />
-                                    </div>
-                                    <div className="flex-1 text-left">
-                                      <div className="font-medium text-sm">{item.title}</div>
-                                      <div className="text-xs text-muted-foreground mt-0.5">{item.description}</div>
-                                    </div>
-                                    <ChevronRight className="h-4 w-4 text-muted-foreground mt-2" />
-                                  </div>
-                                </Button>
-                              </Link>
-                            );
-                          })}
-                        </div>
-                      </div>
-
-                      <Separator />
-
-                      {/* Solutions Section */}
-                      <div>
-                        <div className="flex items-center justify-between mb-3">
-                          <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider">Solutions</h3>
-                          <Badge variant="secondary" className="text-[10px]">6 Solutions</Badge>
-                        </div>
-                        <div className="space-y-1">
-                          {solutionsItems.map((item) => {
-                            const icons: Record<string, any> = {
-                              'App Builder': Code,
-                              'Website Builder': Globe,
-                              'Game Builder': Rocket,
-                              'Dashboard Builder': Monitor,
-                              'Chatbot / AI Agent Builder': MessageSquare,
-                              'AI Agent Internal Builder': Brain
-                            };
-                            const Icon = icons[item.title] || Code;
-                            
-                            return (
-                              <Link key={item.title} href={item.href}>
-                                <Button
-                                  variant="ghost"
-                                  className="mobile-nav-item w-full justify-start h-auto py-3 px-3 hover:bg-muted/80"
-                                  onClick={() => setMobileMenuOpen(false)}
-                                >
-                                  <div className="flex items-start gap-3 w-full">
-                                    <div className="rounded-lg bg-primary/10 p-2 mt-0.5">
-                                      <Icon className="mobile-nav-icon h-4 w-4 text-primary" />
-                                    </div>
-                                    <div className="flex-1 text-left">
-                                      <div className="font-medium text-sm">{item.title}</div>
-                                      <div className="text-xs text-muted-foreground mt-0.5">{item.description}</div>
-                                    </div>
-                                    <ChevronRight className="h-4 w-4 text-muted-foreground mt-2" />
-                                  </div>
-                                </Button>
-                              </Link>
-                            );
-                          })}
-                        </div>
-                      </div>
-
-                      <Separator />
-
-                      {/* Resources Section */}
-                      <div>
-                        <div className="flex items-center justify-between mb-3">
-                          <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider">Resources</h3>
-                          <Badge variant="secondary" className="text-[10px]">6 Items</Badge>
-                        </div>
-                        <div className="space-y-1">
-                          {resourcesItems.map((item) => {
-                            const icons: Record<string, any> = {
-                              'Documentation': BookOpen,
-                              'Blog': Newspaper,
-                              'Community': MessageSquare,
-                              'Templates': FileText,
-                              'Status': Globe,
-                              'Forum': Users
-                            };
-                            const Icon = icons[item.title] || FileText;
-                            
-                            return (
-                              <Link key={item.title} href={item.href}>
-                                <Button
-                                  variant="ghost"
-                                  className="w-full justify-start h-auto py-3 px-3 hover:bg-muted/80"
-                                  onClick={() => setMobileMenuOpen(false)}
-                                >
-                                  <div className="flex items-start gap-3 w-full">
-                                    <div className="rounded-lg bg-muted p-2 mt-0.5">
-                                      <Icon className="h-4 w-4 text-muted-foreground" />
-                                    </div>
-                                    <div className="flex-1 text-left">
-                                      <div className="font-medium text-sm">{item.title}</div>
-                                      <div className="text-xs text-muted-foreground mt-0.5">{item.description}</div>
-                                    </div>
-                                    <ChevronRight className="h-4 w-4 text-muted-foreground mt-2" />
-                                  </div>
-                                </Button>
-                              </Link>
-                            );
-                          })}
-                        </div>
-                      </div>
-
-                      <Separator />
-
-                      {/* Company Section */}
-                      <div>
-                        <div className="flex items-center justify-between mb-3">
-                          <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider">Company</h3>
-                          <Badge variant="secondary" className="text-[10px]">4 Pages</Badge>
-                        </div>
-                        <div className="space-y-1">
-                          {companyItems.map((item) => {
-                            const icons: Record<string, any> = {
-                              'About': Building,
-                              'Careers': Briefcase,
-                              'Press': Newspaper,
-                              'Partners': Handshake
-                            };
-                            const Icon = icons[item.title] || Building;
-                            
-                            return (
-                              <Link key={item.title} href={item.href}>
-                                <Button
-                                  variant="ghost"
-                                  className="w-full justify-start h-auto py-3 px-3 hover:bg-muted/80"
-                                  onClick={() => setMobileMenuOpen(false)}
-                                >
-                                  <div className="flex items-start gap-3 w-full">
-                                    <div className="rounded-lg bg-muted p-2 mt-0.5">
-                                      <Icon className="h-4 w-4 text-muted-foreground" />
-                                    </div>
-                                    <div className="flex-1 text-left">
-                                      <div className="font-medium text-sm">{item.title}</div>
-                                      <div className="text-xs text-muted-foreground mt-0.5">{item.description}</div>
-                                    </div>
-                                    <ChevronRight className="h-4 w-4 text-muted-foreground mt-2" />
-                                  </div>
-                                </Button>
-                              </Link>
-                            );
-                          })}
-                        </div>
-                      </div>
-
-                      <Separator />
-
-                      {/* Quick Links */}
-                      <div className="grid grid-cols-2 gap-3">
-                        <Link href="/pricing">
-                          <Button
-                            variant="outline"
-                            className="w-full h-auto py-3 flex flex-col gap-1"
-                            onClick={() => setMobileMenuOpen(false)}
-                          >
-                            <Star className="h-4 w-4" />
-                            <span className="text-xs">Pricing</span>
-                          </Button>
-                        </Link>
-                        <Link href="/team">
-                          <Button
-                            variant="outline"
-                            className="w-full h-auto py-3 flex flex-col gap-1"
-                            onClick={() => setMobileMenuOpen(false)}
-                          >
-                            <Users className="h-4 w-4" />
-                            <span className="text-xs">Teams</span>
-                          </Button>
-                        </Link>
-                      </div>
+                      ))}
                     </div>
                   </ScrollArea>
-
-                  {/* Footer Actions */}
-                  <div className="border-t bg-background/95 backdrop-blur p-4 space-y-3">
-                    <div className="grid grid-cols-2 gap-3">
-                      <Button 
-                        variant="outline" 
-                        className="w-full"
-                        onClick={() => {
-                          setMobileMenuOpen(false);
-                          setTimeout(() => navigate('/auth'), 150);
-                        }}
-                      >
-                        <LogIn className="h-4 w-4 mr-2" />
-                        Log in
-                      </Button>
-                      <Button 
-                        className="w-full bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700"
-                        onClick={() => {
-                          setMobileMenuOpen(false);
-                          setTimeout(() => navigate('/auth'), 150);
-                        }}
-                      >
-                        Sign up
-                      </Button>
-                    </div>
-                    <div className="flex items-center justify-between px-2">
-                      <ThemeSwitcher />
-                      <Button variant="ghost" size="sm" className="text-xs text-muted-foreground">
-                        <Settings className="h-3 w-3 mr-1" />
-                        Settings
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              </SheetContent>
-            </Sheet>
+                </SheetContent>
+              </Sheet>
+            </div>
           </div>
         </div>
-      </div>
-    </nav>
+      </nav>
+    </header>
   );
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -155,6 +155,21 @@
   .max-w-responsive {
     @apply max-w-full sm:max-w-xl md:max-w-2xl lg:max-w-4xl xl:max-w-6xl mx-auto;
   }
+
+  .bg-marketing-surface {
+    @apply bg-slate-950 text-slate-50;
+  }
+
+  .glass-panel {
+    background-color: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: 0 20px 45px -25px rgba(15, 23, 42, 0.6);
+    backdrop-filter: blur(24px);
+  }
+
+  .glass-border {
+    border-color: rgba(148, 163, 184, 0.3);
+  }
 }
 
 /* Mobile-first responsive adjustments */
@@ -198,6 +213,42 @@
 /* Replit-style hover and focus states */
 .replit-hover-scale {
   transition: transform 150ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.marketing-backdrop {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.18), transparent 55%),
+    radial-gradient(circle at top right, rgba(59, 130, 246, 0.15), transparent 50%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.9), rgba(2, 6, 23, 0.92));
+  filter: blur(40px);
+  opacity: 0.9;
+  z-index: 0;
+}
+
+.marketing-gradient {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(125, 211, 252, 0.12), transparent 45%),
+    radial-gradient(circle at 80% 20%, rgba(147, 197, 253, 0.12), transparent 50%),
+    radial-gradient(circle at 50% 70%, rgba(129, 140, 248, 0.1), transparent 40%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.marketing-grid {
+  position: absolute;
+  inset: 0;
+  background-size: 56px 56px;
+  background-image: linear-gradient(to right, rgba(148, 163, 184, 0.07) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(148, 163, 184, 0.07) 1px, transparent 1px);
+  mask-image: radial-gradient(circle at center, black, transparent 75%);
+  pointer-events: none;
+}
+
+.marketing-divider {
+  background: linear-gradient(90deg, rgba(59, 130, 246, 0), rgba(59, 130, 246, 0.3), rgba(59, 130, 246, 0));
+  height: 1px;
 }
 
 .replit-hover-scale:hover {

--- a/client/src/pages/FeaturePlaceholder.tsx
+++ b/client/src/pages/FeaturePlaceholder.tsx
@@ -1,0 +1,207 @@
+// @ts-nocheck
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Sparkles, ShieldCheck, Clock3 } from 'lucide-react';
+
+const featureCopy: Record<string, {
+  title: string;
+  subtitle: string;
+  summary: string;
+  highlights: string[];
+}> = {
+  assistant: {
+    title: 'AI Assistant',
+    subtitle: 'Conversational development copilot',
+    summary: 'Ask questions about your codebase, auto-generate documentation, and unblock your teams with contextual intelligence.',
+    highlights: ['Understands your repository, tests, and deployments', 'Enterprise controls with audit trails and policy guardrails', 'Available across web, mobile, and desktop apps'],
+  },
+  database: {
+    title: 'Managed Database Studio',
+    subtitle: 'Command the data layer with zero friction',
+    summary: 'Provision, manage, and observe your databases with AI-assisted migrations, schema visualizations, and performance insights.',
+    highlights: ['AI-assisted migration planning', 'Automated backups and failover', 'Integrated query insights and alerts'],
+  },
+  console: {
+    title: 'Command Console',
+    subtitle: 'Secure shell, logs, and observability in one place',
+    summary: 'Gain instant access to runtime logs, shell access, and metrics dashboards through a unified console experience.',
+    highlights: ['Role-based access for operations teams', 'Full audit history of shell sessions', 'Deep links into traces and deployments'],
+  },
+  authentication: {
+    title: 'Authentication Hub',
+    subtitle: 'Streamlined auth experiences for every app',
+    summary: 'Integrate SSO, passwordless login, and social sign-on with built-in compliance controls.',
+    highlights: ['Supports SAML, OIDC, and passwordless flows', 'Centralized policy management and analytics', 'Fully branded experiences and user lifecycle automations'],
+  },
+  preview: {
+    title: 'Preview Environments',
+    subtitle: 'On-demand environments for every change',
+    summary: 'Spin up secure preview environments with generated fixtures, QA checklists, and collaboration tools.',
+    highlights: ['Automatic URL for every pull request', 'AI generated test plans and review summaries', 'Usage analytics and tear-down scheduling'],
+  },
+  agent: {
+    title: 'Agent Control Center',
+    subtitle: 'Manage, govern, and monitor your AI agents',
+    summary: 'Operationalize AI in production with real-time observability, approval workflows, and safety checks.',
+    highlights: ['Fine-grained permissions and scopes', 'Live session replay and analytics', 'Policy and compliance automation'],
+  },
+  'code-search': {
+    title: 'Code Search',
+    subtitle: 'Semantic search across every repository',
+    summary: 'Discover patterns, anti-patterns, and reusable components with AI-powered insights across your codebase.',
+    highlights: ['Natural language queries with vector search', 'Compliance and license filters', 'Cross-language understanding'],
+  },
+  packages: {
+    title: 'Package Intelligence',
+    subtitle: 'Safe dependencies at enterprise scale',
+    summary: 'Audit vulnerabilities, licenses, and supply-chain risks with automated remediation workflows.',
+    highlights: ['Continuous CVE monitoring and auto-patches', 'Policy-driven approvals', 'SBOM exports and compliance reports'],
+  },
+  extensions: {
+    title: 'Extensions Marketplace',
+    subtitle: 'Curate private integrations and workflows',
+    summary: 'Bring your toolchain directly into the workspace with vetted, secure extensions tailored to your teams.',
+    highlights: ['Private marketplace support', 'Role and permission aware extensions', 'Lifecycle management and analytics'],
+  },
+  integrations: {
+    title: 'Integration Hub',
+    subtitle: 'Connect your ecosystem in minutes',
+    summary: 'Prebuilt connectors for CI/CD, observability, support, and data services with centralized governance.',
+    highlights: ['200+ enterprise integrations', 'Granular secrets management', 'Event streaming and webhooks'],
+  },
+  networking: {
+    title: 'Networking Control Plane',
+    subtitle: 'Secure connectivity for hybrid deployments',
+    summary: 'Control ingress, egress, and private connectivity with fine-grained policies and observability.',
+    highlights: ['Private networking and VPC peering', 'Zero-trust access policies', 'Global traffic management'],
+  },
+  problems: {
+    title: 'Issue Intelligence',
+    subtitle: 'Proactively resolve incidents with AI triage',
+    summary: 'Detect, prioritize, and resolve incidents using AI-driven root-cause analysis and recommended playbooks.',
+    highlights: ['Noise reduction with ML-based correlation', 'Automated postmortem generation', 'Workflow integrations with PagerDuty and Jira'],
+  },
+  'kv-store': {
+    title: 'Distributed KV Store',
+    subtitle: 'Ultra-fast key-value storage for serverless apps',
+    summary: 'Provision globally available KV storage with built-in replication, caching, and analytics.',
+    highlights: ['Low-latency global reads and writes', 'Auto-scaling with zero maintenance', 'Audit logging and TTL policies'],
+  },
+  shell: {
+    title: 'Secure Shell',
+    subtitle: 'Production-grade terminal in the browser',
+    summary: 'Give teams audited, role-aware shell access without exposing infrastructure keys.',
+    highlights: ['Session recording and approvals', 'Just-in-time credentials', 'Command policy enforcement'],
+  },
+  threads: {
+    title: 'Collaboration Threads',
+    subtitle: 'Async conversations anchored to your code',
+    summary: 'Embed discussions, reviews, and decisions directly in the workspace for transparent knowledge sharing.',
+    highlights: ['Attach to files, lines, or deployments', 'AI summaries and next steps', 'Integrations with Slack and Teams'],
+  },
+  vnc: {
+    title: 'Visual Workspace',
+    subtitle: 'Graphical access to managed environments',
+    summary: 'Secure browser-based desktop for design tooling, data visualization, and legacy workflows.',
+    highlights: ['Pixel-perfect streaming performance', 'Policy-controlled clipboard and downloads', 'Session analytics and compliance logging'],
+  },
+  referrals: {
+    title: 'Referral Hub',
+    subtitle: 'Reward your network for building on E-Code',
+    summary: 'Launch global referral campaigns with transparent tracking, insights, and flexible incentives.',
+    highlights: ['Customizable incentive structures', 'Real-time performance dashboards', 'Automated payouts and compliance'],
+  },
+  'teams/new': {
+    title: 'Team Launchpad',
+    subtitle: 'Spin up new teams with enterprise guardrails',
+    summary: 'Template onboarding, permissions, and workspace configuration for new teams in minutes.',
+    highlights: ['Automated workspace provisioning', 'Policy-based permission templates', 'Analytics on activation and usage'],
+  },
+};
+
+interface FeaturePlaceholderProps {
+  featureKey: string;
+}
+
+export default function FeaturePlaceholder({ featureKey }: FeaturePlaceholderProps) {
+  const copy = featureCopy[featureKey] ?? featureCopy.assistant;
+
+  return (
+    <div className="px-responsive py-12 text-slate-100">
+      <div className="mx-auto max-w-5xl space-y-10">
+        <header className="text-center space-y-4">
+          <Badge className="bg-white/10 text-white border-white/20">Coming soon</Badge>
+          <h1 className="text-4xl font-semibold text-white">{copy.title}</h1>
+          <p className="text-lg text-slate-300">{copy.subtitle}</p>
+          <p className="mx-auto max-w-3xl text-slate-300 leading-relaxed">{copy.summary}</p>
+        </header>
+
+        <div className="grid gap-6 sm:grid-cols-2">
+          {copy.highlights.map((highlight) => (
+            <Card key={highlight} className="bg-white/5 border-white/10">
+              <CardHeader className="flex items-start gap-3">
+                <div className="rounded-full bg-white/10 p-3 text-sky-200">
+                  <Sparkles className="h-5 w-5" />
+                </div>
+                <CardTitle className="text-base text-white leading-relaxed">{highlight}</CardTitle>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+
+        <Card className="bg-gradient-to-r from-slate-900 via-slate-950 to-slate-900 border-white/10">
+          <CardContent className="grid gap-8 py-10 sm:grid-cols-2">
+            <div className="space-y-3">
+              <CardTitle className="text-2xl text-white">Enterprise preview access</CardTitle>
+              <CardDescription className="text-slate-300">
+                We’re partnering with select enterprises to shape the roadmap. Get early access, dedicated solution architects, and influence the product direction.
+              </CardDescription>
+            </div>
+            <div className="space-y-3">
+              <Button className="w-full bg-gradient-to-r from-sky-400 via-blue-500 to-indigo-500 text-white" onClick={() => (window.location.href = '/contact-sales')}>
+                Request early access
+              </Button>
+              <Button variant="outline" className="w-full border-white/20 text-slate-100 hover:text-white" onClick={() => (window.location.href = '/docs')}>
+                View documentation
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="grid gap-6 sm:grid-cols-3">
+          {[{
+            title: 'Security by default',
+            description: 'SOC2 Type II controls, audit logging, and fine-grained RBAC protect every action.',
+          }, {
+            title: 'Accelerated delivery',
+            description: 'AI guided workflows remove busywork so teams can focus on strategic initiatives.',
+          }, {
+            title: 'Operational confidence',
+            description: 'Real-time insights keep stakeholders aligned with progress and impact.',
+          }].map((item) => (
+            <Card key={item.title} className="bg-white/5 border-white/10">
+              <CardHeader>
+                <CardTitle className="text-lg text-white">{item.title}</CardTitle>
+                <CardDescription className="text-slate-300 leading-relaxed">{item.description}</CardDescription>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+
+        <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-300">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-3 text-slate-200">
+              <ShieldCheck className="h-5 w-5 text-emerald-300" />
+              <span>Enterprise roadmap partner program</span>
+            </div>
+            <div className="flex items-center gap-3 text-slate-200">
+              <Clock3 className="h-5 w-5 text-sky-300" />
+              <span>Priority onboarding and support SLAs</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/Forum.tsx
+++ b/client/src/pages/Forum.tsx
@@ -1,0 +1,129 @@
+// @ts-nocheck
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { MarketingLayout } from '@/components/layout/MarketingLayout';
+import { Megaphone, MessageSquare, Users, Award, ArrowUpRight } from 'lucide-react';
+
+const featuredThreads = [
+  {
+    title: 'Scaling E-Code for a global enterprise rollout',
+    description: 'Best practices from teams rolling out secure AI development across 10,000+ seats.',
+    category: 'Enterprise',
+    replies: 128,
+  },
+  {
+    title: 'Recommended workflows for AI agent assisted development',
+    description: 'Share your playbooks for combining AI agents with compliance guardrails.',
+    category: 'AI',
+    replies: 94,
+  },
+  {
+    title: 'From PoC to production: winning strategies',
+    description: 'A step-by-step checklist from CTOs on moving from prototype to production inside E-Code.',
+    category: 'Leadership',
+    replies: 76,
+  },
+];
+
+const categories = [
+  { label: 'Announcements', icon: Megaphone, description: 'Platform updates, roadmap reveals, and release notes.' },
+  { label: 'Implementation', icon: Users, description: 'Architecture patterns, deployment questions, and how-to guides.' },
+  { label: 'AI & Automation', icon: MessageSquare, description: 'Prompt engineering, agent operations, and AI governance.' },
+  { label: 'Champions', icon: Award, description: 'Spotlights on teams shipping faster with E-Code.' },
+];
+
+export default function Forum() {
+  return (
+    <MarketingLayout>
+      <section className="relative overflow-hidden py-16">
+        <div className="container-responsive max-w-5xl text-center">
+          <Badge className="mx-auto mb-6 bg-white/10 text-white border-white/20">Global developer forum</Badge>
+          <h1 className="text-4xl sm:text-5xl font-semibold text-white tracking-tight">
+            Connect with the E-Code community
+          </h1>
+          <p className="mt-4 text-base sm:text-lg text-slate-200 max-w-3xl mx-auto">
+            Learn from engineers building at enterprise scale, share feedback with our product teams, and stay ahead with curated best practices.
+          </p>
+          <div className="mt-8 flex flex-wrap justify-center gap-4">
+            <Button className="bg-gradient-to-r from-sky-400 via-blue-500 to-indigo-500 text-white shadow-blue-500/30" onClick={() => (window.location.href = '/register')}>
+              Join the forum
+              <ArrowUpRight className="ml-2 h-4 w-4" />
+            </Button>
+            <Button variant="outline" className="border-white/20 text-slate-100 hover:text-white" onClick={() => (window.location.href = '/contact-sales')}>
+              Request a tailored workshop
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container-responsive max-w-6xl grid gap-6 lg:grid-cols-3">
+          {featuredThreads.map((thread) => (
+            <Card key={thread.title} className="bg-white/5 border-white/10 text-left">
+              <CardHeader>
+                <Badge variant="outline" className="w-fit border-white/30 text-slate-100">{thread.category}</Badge>
+                <CardTitle className="text-xl text-white">{thread.title}</CardTitle>
+                <CardDescription className="text-slate-300 leading-relaxed">{thread.description}</CardDescription>
+              </CardHeader>
+              <CardContent className="flex items-center justify-between text-sm text-slate-300">
+                <div className="flex items-center gap-3">
+                  <Avatar className="h-9 w-9 border border-white/20">
+                    <AvatarFallback className="bg-sky-500/20 text-sky-100">EC</AvatarFallback>
+                  </Avatar>
+                  <div>
+                    <p className="font-medium text-white">E-Code Enterprise Team</p>
+                    <p className="text-xs text-slate-400">Official insights & resources</p>
+                  </div>
+                </div>
+                <span className="rounded-full bg-white/10 px-3 py-1 text-xs">{thread.replies} replies</span>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container-responsive max-w-6xl">
+          <div className="grid gap-6 sm:grid-cols-2">
+            {categories.map((category) => (
+              <Card key={category.label} className="bg-white/5 border-white/10">
+                <CardHeader className="flex items-center gap-4">
+                  <div className="rounded-full bg-white/10 p-3 text-sky-200">
+                    <category.icon className="h-6 w-6" />
+                  </div>
+                  <div>
+                    <CardTitle className="text-lg text-white">{category.label}</CardTitle>
+                    <CardDescription className="text-slate-300 leading-relaxed">{category.description}</CardDescription>
+                  </div>
+                </CardHeader>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="pb-20">
+        <div className="container-responsive max-w-4xl">
+          <Card className="bg-gradient-to-r from-slate-900 via-slate-950 to-slate-900 border-white/10">
+            <CardContent className="flex flex-col items-center gap-6 py-12 text-center">
+              <h2 className="text-3xl font-semibold text-white">Bring E-Code to your organization</h2>
+              <p className="max-w-2xl text-slate-300">
+                Partner with our enterprise architects for tailored onboarding, SOC2 compliant deployments, and on-site enablement programs.
+              </p>
+              <div className="flex flex-wrap justify-center gap-4">
+                <Button className="bg-gradient-to-r from-sky-400 via-blue-500 to-indigo-500 text-white" onClick={() => (window.location.href = '/contact-sales')}>
+                  Schedule a briefing
+                </Button>
+                <Button variant="outline" className="border-white/20 text-slate-100 hover:text-white" onClick={() => (window.location.href = '/pricing')}>
+                  Explore pricing
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+    </MarketingLayout>
+  );
+}

--- a/client/src/pages/Landing.tsx
+++ b/client/src/pages/Landing.tsx
@@ -14,8 +14,7 @@ import {
   Play, Pause, Volume2, VolumeX, Maximize, Globe2
 } from 'lucide-react';
 import { useState, useRef } from 'react';
-import { PublicNavbar } from '@/components/layout/PublicNavbar';
-import { PublicFooter } from '@/components/layout/PublicFooter';
+import { MarketingLayout } from '@/components/layout/MarketingLayout';
 import { MobileChatInterface } from '@/components/MobileChatInterface';
 import { AnimatedPlatformDemo } from '@/components/AnimatedPlatformDemo';
 import { useToast } from '@/hooks/use-toast';
@@ -237,24 +236,22 @@ export default function Landing() {
   };
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <PublicNavbar />
+    <MarketingLayout>
 
       {/* Hero Section */}
-      <section className="py-8 sm:py-12 md:py-16 lg:py-20">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-6xl">
-          <div className="text-center space-y-4 sm:space-y-6">
-            <Badge variant="secondary" className="mb-2 sm:mb-4 animate-pulse text-xs sm:text-sm">
-              <Sparkles className="h-3 w-3 mr-1" />
+      <section className="relative overflow-hidden py-12 sm:py-16 lg:py-24">
+        <div className="marketing-grid" aria-hidden />
+        <div className="container-responsive relative max-w-6xl text-center">
+          <div className="space-y-5 sm:space-y-7">
+            <Badge variant="secondary" className="mx-auto inline-flex items-center gap-2 rounded-full border-white/20 bg-white/10 text-white backdrop-blur">
+              <Sparkles className="h-4 w-4" />
               Build apps and sites with AI
             </Badge>
-            <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-bold leading-tight">
-              Build <span className="bg-gradient-to-r from-violet-600 to-fuchsia-600 bg-clip-text text-transparent">anything</span>
-              <br className="hidden sm:block" />
-              <span className="sm:ml-2">with AI</span>
+            <h1 className="text-3xl sm:text-5xl lg:text-6xl xl:text-7xl font-semibold tracking-tight text-white">
+              Fortune 500 development velocity for every team
             </h1>
-            <p className="text-base sm:text-lg md:text-xl text-muted-foreground max-w-2xl mx-auto px-4 sm:px-0 font-medium">
-              Describe your idea and watch AI build it. From simple websites to complex applications.
+            <p className="mx-auto max-w-2xl text-base sm:text-lg text-slate-200">
+              Describe the product. Our AI agents design, code, test, and deploy secure applications in minutes across web, mobile, and cloud.
             </p>
             
             {/* Lovable.dev Exact Style Chat Input */}
@@ -1540,7 +1537,7 @@ export default function Landing() {
 
       {/* Language Showcase */}
       <section className="py-20 bg-gradient-to-b from-muted/30 to-background">
-        <div className="container mx-auto max-w-6xl px-4">
+        <div className="container-responsive max-w-6xl px-4">
           <div className="text-center mb-12">
             <h2 className="text-3xl md:text-4xl font-bold mb-4">
               Code in your favorite language
@@ -1755,7 +1752,7 @@ export default function Landing() {
 
       {/* Features Section */}
       <section id="features" className="py-20 px-4 bg-muted/30">
-        <div className="container mx-auto max-w-6xl">
+        <div className="container-responsive max-w-6xl">
           <div className="text-center mb-12">
             <h2 className="text-3xl md:text-4xl font-bold mb-4">
               Everything you need to succeed
@@ -1792,7 +1789,7 @@ export default function Landing() {
 
       {/* Use Cases */}
       <section className="py-20 px-4">
-        <div className="container mx-auto max-w-6xl">
+        <div className="container-responsive max-w-6xl">
           <div className="text-center mb-12">
             <h2 className="text-3xl md:text-4xl font-bold mb-4">
               Made for everyone
@@ -1899,7 +1896,7 @@ export default function Landing() {
 
       {/* Testimonials */}
       <section id="testimonials" className="py-20 px-4 bg-muted/30">
-        <div className="container mx-auto max-w-6xl">
+        <div className="container-responsive max-w-6xl">
           <div className="text-center mb-12">
             <h2 className="text-3xl md:text-4xl font-bold mb-4">
               Loved by developers
@@ -1937,7 +1934,7 @@ export default function Landing() {
 
       {/* CTA Section */}
       <section className="py-20 px-4">
-        <div className="container mx-auto max-w-4xl">
+        <div className="container-responsive max-w-4xl">
           <Card className="bg-primary text-primary-foreground">
             <CardContent className="p-12 text-center">
               <h2 className="text-3xl md:text-4xl font-bold mb-4">
@@ -1967,7 +1964,6 @@ export default function Landing() {
         </div>
       </section>
 
-      <PublicFooter />
-    </div>
+    </MarketingLayout>
   );
 }

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -134,7 +134,7 @@ export default function Pricing() {
     if (tier.enterprise) {
       navigate('/contact-sales');
     } else if (user) {
-      navigate('/billing');
+      navigate('/subscribe');
     } else {
       navigate('/auth');
     }

--- a/client/src/pages/Usage.tsx
+++ b/client/src/pages/Usage.tsx
@@ -148,7 +148,7 @@ export default function Usage() {
   };
   
   const handleManageStorage = () => {
-    navigate('/settings/storage');
+    navigate('/settings');
   };
   
   const handleComparePlans = () => {

--- a/client/src/pages/compare/ComparePage.tsx
+++ b/client/src/pages/compare/ComparePage.tsx
@@ -1,0 +1,130 @@
+// @ts-nocheck
+import { useRoute } from 'wouter';
+import { MarketingLayout } from '@/components/layout/MarketingLayout';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { CheckCircle2, ShieldCheck, Clock3, ServerCog, Sparkles } from 'lucide-react';
+
+const comparisonContent: Record<string, {
+  heroTitle: string;
+  description: string;
+  highlights: string[];
+  differentiators: Array<{ title: string; description: string }>;
+}> = {
+  'github-codespaces': {
+    heroTitle: 'E-Code vs GitHub Codespaces',
+    description: 'Ship faster with AI-native automation, real-time collaboration, and enterprise controls that go beyond hosted containers.',
+    highlights: ['AI agents that build full-stack apps end-to-end', 'Dedicated enterprise regions and private networking', 'Native mobile & desktop apps for on-the-go productivity'],
+    differentiators: [
+      { title: 'AI-first workflow', description: 'Agents write, review, test, and deploy code with policy guardrails baked in.' },
+      { title: 'Enterprise-grade governance', description: 'Granular RBAC, audit trails, and compliance packs for SOC2, HIPAA, and GDPR.' },
+      { title: 'Unified experience', description: 'Consistent IDE across browser, mobile, and desktop with multiplayer collaboration.' },
+    ],
+  },
+  glitch: {
+    heroTitle: 'E-Code vs Glitch',
+    description: 'Go beyond prototyping to production with scalable infrastructure, integrated databases, and secure deployments.',
+    highlights: ['Persistent production environments', 'Integrated observability and analytics', 'Custom domains with managed SSL'],
+    differentiators: [
+      { title: 'Production ready', description: 'Provision multi-region infrastructure with zero downtime deploys.' },
+      { title: 'Secure by design', description: 'Role-based access, secrets management, and network isolation included.' },
+      { title: 'Data services', description: 'Managed Postgres, object storage, and queue services ready out of the box.' },
+    ],
+  },
+  heroku: {
+    heroTitle: 'E-Code vs Heroku',
+    description: 'Combine AI-assisted development with enterprise deployment automation on a unified platform.',
+    highlights: ['Full-stack IDE with AI pair programming', 'Policy-driven deployments and rollbacks', 'Integrated monitoring & incident response'],
+    differentiators: [
+      { title: 'All-in-one workspace', description: 'Develop, test, and ship without context switching between local and remote tools.' },
+      { title: 'AI automation', description: 'Automated scaffolding, migrations, and security reviews accelerate delivery.' },
+      { title: 'Scalable architecture', description: 'Deploy to global edge regions with auto-scaling and private networking.' },
+    ],
+  },
+  codesandbox: {
+    heroTitle: 'E-Code vs CodeSandbox',
+    description: 'Level up collaborative development with enterprise compliance, AI agents, and production-ready deployments.',
+    highlights: ['Real-time multiplayer with voice rooms', 'AI code reviews & auto-resolves', 'SAML SSO, audit logs, and data residency'],
+    differentiators: [
+      { title: 'Enterprise collaboration', description: 'Shared environments, project analytics, and workspace templates built for scale.' },
+      { title: 'Governed AI', description: 'Compliance-ready AI assistance with approvals, policy guardrails, and reporting.' },
+      { title: 'Deployment freedom', description: 'Deploy to the E-Code edge or your own VPC with the same workflow.' },
+    ],
+  },
+  'aws-cloud9': {
+    heroTitle: 'E-Code vs AWS Cloud9',
+    description: 'Modernize development with AI automation, zero-maintenance workspaces, and enterprise-class observability.',
+    highlights: ['Zero-maintenance environments', 'Integrated CI/CD and incident response', 'Secure collaboration with workspace isolation'],
+    differentiators: [
+      { title: 'AI co-pilots', description: 'Agents manage environment setup, package updates, and dependency security patches.' },
+      { title: 'Observability suite', description: 'Centralized logs, metrics, and alerts integrated with Slack and PagerDuty.' },
+      { title: 'Enterprise operations', description: 'Automated backups, disaster recovery, and compliance reporting included.' },
+    ],
+  },
+};
+
+export default function ComparePage() {
+  const [, params] = useRoute('/compare/:slug');
+  const slug = params?.slug ?? 'github-codespaces';
+  const content = comparisonContent[slug] ?? comparisonContent['github-codespaces'];
+
+  return (
+    <MarketingLayout>
+      <section className="relative overflow-hidden py-16">
+        <div className="container-responsive max-w-5xl text-center">
+          <Badge className="mx-auto mb-4 bg-white/10 text-white border-white/20">Platform comparison</Badge>
+          <h1 className="text-4xl sm:text-5xl font-semibold text-white tracking-tight">{content.heroTitle}</h1>
+          <p className="mt-4 text-base sm:text-lg text-slate-200 max-w-3xl mx-auto">{content.description}</p>
+          <div className="mt-8 grid gap-4 sm:grid-cols-3 text-left">
+            {content.highlights.map((highlight) => (
+              <div key={highlight} className="rounded-2xl border border-white/10 bg-white/5 p-5">
+                <CheckCircle2 className="mb-3 h-5 w-5 text-emerald-300" />
+                <p className="text-sm text-slate-200 leading-relaxed">{highlight}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container-responsive max-w-6xl grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {content.differentiators.map((item) => (
+            <Card key={item.title} className="bg-white/5 border-white/10">
+              <CardHeader>
+                <CardTitle className="text-lg text-white">{item.title}</CardTitle>
+                <CardDescription className="text-slate-300 leading-relaxed">{item.description}</CardDescription>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section className="pb-20">
+        <div className="container-responsive max-w-5xl">
+          <Card className="bg-gradient-to-r from-slate-900 via-slate-950 to-slate-900 border-white/10">
+            <CardContent className="grid gap-6 py-10 text-center sm:text-left sm:grid-cols-2">
+              <div className="space-y-4">
+                <h2 className="text-3xl font-semibold text-white">Why enterprises choose E-Code</h2>
+                <ul className="space-y-2 text-slate-300 text-sm">
+                  <li className="flex items-start gap-2"><ShieldCheck className="mt-1 h-4 w-4 text-emerald-300" /> Dedicated private cloud, SOC2 Type II, HIPAA, and GDPR compliance.</li>
+                  <li className="flex items-start gap-2"><Clock3 className="mt-1 h-4 w-4 text-sky-300" /> Accelerated delivery with AI agents, reusable blueprints, and automated QA.</li>
+                  <li className="flex items-start gap-2"><ServerCog className="mt-1 h-4 w-4 text-indigo-300" /> Global infrastructure footprint with advanced observability.</li>
+                  <li className="flex items-start gap-2"><Sparkles className="mt-1 h-4 w-4 text-purple-300" /> Continuous innovation with a unified experience across devices.</li>
+                </ul>
+              </div>
+              <div className="flex flex-col gap-3">
+                <Button className="bg-gradient-to-r from-sky-400 via-blue-500 to-indigo-500 text-white" onClick={() => (window.location.href = '/contact-sales')}>
+                  Book a personalized demo
+                </Button>
+                <Button variant="outline" className="border-white/20 text-slate-100 hover:text-white" onClick={() => (window.location.href = '/pricing')}>
+                  View pricing
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+    </MarketingLayout>
+  );
+}

--- a/client/src/pages/solutions/InternalAIBuilder.tsx
+++ b/client/src/pages/solutions/InternalAIBuilder.tsx
@@ -1,0 +1,104 @@
+// @ts-nocheck
+import { MarketingLayout } from '@/components/layout/MarketingLayout';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ShieldCheck, Users, Workflow, Lock, Cpu, Rocket } from 'lucide-react';
+
+const capabilities = [
+  {
+    icon: ShieldCheck,
+    title: 'Enterprise-grade security',
+    description: 'SOC2 Type II controls, granular RBAC, and private networking for regulated workloads.',
+  },
+  {
+    icon: Users,
+    title: 'Team-aware automation',
+    description: 'Contextual agents that understand org structures, permissions, and project history.',
+  },
+  {
+    icon: Workflow,
+    title: 'Workflow orchestration',
+    description: 'Trigger complex build, review, and deployment sequences tailored to your SDLC.',
+  },
+  {
+    icon: Lock,
+    title: 'Policy guardrails',
+    description: 'Ensure every action respects security policies with real-time observability and approvals.',
+  },
+  {
+    icon: Cpu,
+    title: 'Model flexibility',
+    description: 'Bring your own models or leverage E-Code tuned models with governance baked in.',
+  },
+  {
+    icon: Rocket,
+    title: 'Faster delivery',
+    description: 'Reduce cycle times with reusable templates, automation kits, and instant deployments.',
+  },
+];
+
+export default function InternalAIBuilder() {
+  return (
+    <MarketingLayout>
+      <section className="relative overflow-hidden py-16">
+        <div className="container-responsive max-w-5xl text-center">
+          <Badge className="mx-auto mb-6 bg-white/10 text-white border-white/20">Internal AI Builder</Badge>
+          <h1 className="text-4xl sm:text-5xl font-semibold text-white tracking-tight">
+            Private AI agents for every team
+          </h1>
+          <p className="mt-4 text-base sm:text-lg text-slate-200">
+            Deploy governed AI agents that work across engineering, design, and operations—without compromising compliance or control.
+          </p>
+          <div className="mt-8 flex flex-wrap justify-center gap-4">
+            <Button className="bg-gradient-to-r from-sky-400 via-blue-500 to-indigo-500 text-white" onClick={() => (window.location.href = '/contact-sales')}>
+              Talk to an enterprise specialist
+            </Button>
+            <Button variant="outline" className="border-white/20 text-slate-100 hover:text-white" onClick={() => (window.location.href = '/pricing')}>
+              View pricing options
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container-responsive max-w-6xl grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {capabilities.map((capability) => (
+            <Card key={capability.title} className="bg-white/5 border-white/10">
+              <CardHeader className="space-y-4">
+                <div className="inline-flex rounded-full bg-white/10 p-3 text-sky-200">
+                  <capability.icon className="h-6 w-6" />
+                </div>
+                <CardTitle className="text-lg text-white">{capability.title}</CardTitle>
+                <CardDescription className="text-slate-300 leading-relaxed">{capability.description}</CardDescription>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section className="pb-20">
+        <div className="container-responsive max-w-5xl">
+          <Card className="bg-gradient-to-r from-slate-900 via-slate-950 to-slate-900 border-white/10">
+            <CardContent className="grid gap-8 py-12 text-center sm:text-left sm:grid-cols-[1.5fr_1fr]">
+              <div className="space-y-4">
+                <h2 className="text-3xl font-semibold text-white">Launch an internal AI center of excellence</h2>
+                <p className="text-slate-300">
+                  E-Code provides playbooks, governance frameworks, and dedicated solution architects to help you operationalize AI responsibly across your organization.
+                </p>
+              </div>
+              <div className="flex flex-col gap-3">
+                <Button className="bg-gradient-to-r from-sky-400 via-blue-500 to-indigo-500 text-white" onClick={() => (window.location.href = '/contact-sales')}>
+                  Schedule an executive briefing
+                </Button>
+                <Button variant="outline" className="border-white/20 text-slate-100 hover:text-white" onClick={() => (window.location.href = '/docs')}>
+                  Explore documentation
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+    </MarketingLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce a reusable marketing layout and redesign the public navigation/footer for a Fortune-500 level aesthetic
- refresh the landing page and add new marketing surfaces (forum, comparison, internal AI builder) while addressing newsletter and solutions routing gaps
- add feature placeholder screens and update route configuration to prevent 404s from spotlight, command palette, and marketing links

## Testing
- npm run check *(fails: existing TypeScript errors in server/storage.ts unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f4a646ba9883209bfcb13a88b0bb72