### PR TITLE
Fix plural project route handling

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -435,6 +435,11 @@ function AppContent() {
               <ProjectsPage />
             </ReplitLayout>
           )} />
+          <ProtectedRoute path="/projects/:id" component={() => (
+            <ReplitLayout showSidebar={true}>
+              <ProjectPage />
+            </ReplitLayout>
+          )} />
           {/* Project Routes - Consolidated and properly ordered */}
           <ProtectedRoute path="/project/:id" component={() => (
             <ReplitLayout showSidebar={true}>

--- a/client/src/components/layout/ReplitHeader.tsx
+++ b/client/src/components/layout/ReplitHeader.tsx
@@ -77,7 +77,7 @@ export function ReplitHeader() {
   const { toast } = useToast();
 
   // Get project info from URL - supports both formats: /projects/:id and /@:username/:project
-  const pathMatch = location.match(/^\/projects\/(\d+)/);
+  const pathMatch = location.match(/^\/project(?:s)?\/(\d+)/);
   const projectId = pathMatch ? pathMatch[1] : null;
   
   const replitStyleMatch = location.match(/^\/@([^/]+)\/([^/]+)/);
@@ -155,7 +155,7 @@ export function ReplitHeader() {
                     if (projectInfo?.owner?.username && projectInfo?.slug) {
                       navigate(`/@${projectInfo.owner.username}/${projectInfo.slug}`);
                     } else {
-                      navigate(`/projects/${projectId}`);
+                      navigate(`/project/${projectId}`);
                     }
                   }}
                 >
@@ -202,7 +202,7 @@ export function ReplitHeader() {
                         title: "Project Forked",
                         description: `Successfully forked project as "${forkedProject.name}"`,
                       });
-                      navigate(`/projects/${forkedProject.id}`);
+                      navigate(`/project/${forkedProject.id}`);
                     } catch (error) {
                       toast({
                         title: "Fork Failed",

--- a/client/src/pages/ProjectPage.tsx
+++ b/client/src/pages/ProjectPage.tsx
@@ -92,11 +92,7 @@ const ProjectPage = () => {
 
   // Determine if we're using ID or slug route
   const isSlugRoute = !!matchSlug && paramsSlug?.username && paramsSlug?.projectname;
-  const projectIdParam = matchId
-    ? paramsId?.id
-    : matchLegacyId
-      ? paramsLegacyId?.id
-      : null;
+  const projectIdParam = paramsId?.id || paramsLegacyId?.id || null;
   const projectId = projectIdParam ? parseInt(projectIdParam, 10) : null;
   const projectSlug = isSlugRoute ? `@${paramsSlug.username}/${paramsSlug.projectname}` : null;
   const [selectedFile, setSelectedFile] = useState<File | null>(null);

--- a/client/src/pages/ProjectPage.tsx
+++ b/client/src/pages/ProjectPage.tsx
@@ -85,13 +85,19 @@ import { Spinner } from '@/components/ui/spinner';
 
 const ProjectPage = () => {
   const [matchId, paramsId] = useRoute('/project/:id');
+  const [matchLegacyId, paramsLegacyId] = useRoute('/projects/:id');
   const [matchSlug, paramsSlug] = useRoute('/@:username/:projectname');
   const [, navigate] = useLocation();
   const { toast } = useToast();
 
   // Determine if we're using ID or slug route
   const isSlugRoute = !!matchSlug && paramsSlug?.username && paramsSlug?.projectname;
-  const projectId = matchId && paramsId?.id ? parseInt(paramsId.id) : null;
+  const projectIdParam = matchId
+    ? paramsId?.id
+    : matchLegacyId
+      ? paramsLegacyId?.id
+      : null;
+  const projectId = projectIdParam ? parseInt(projectIdParam, 10) : null;
   const projectSlug = isSlugRoute ? `@${paramsSlug.username}/${paramsSlug.projectname}` : null;
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [unsavedChanges, setUnsavedChanges] = useState<Record<number, string>>({});


### PR DESCRIPTION
## Summary
- allow the IDE to resolve both `/project/:id` and legacy `/projects/:id` routes
- wire the app router to serve the project page for the plural path as well
- normalize header navigation so fallback links use the canonical singular route while still matching both forms

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f4aca44d2883209c06d4a7841015dd