### PR TITLE
Document QA automation blockers

### DIFF
--- a/reports/full-QA-report-20251019T125605Z.json
+++ b/reports/full-QA-report-20251019T125605Z.json
@@ -1,0 +1,50 @@
+{
+  "metadata": {
+    "generatedAt": "2025-10-19T12:56:05Z",
+    "environment": {
+      "runner": "OpenAI container",
+      "nodeVersion": "v22.19.0",
+      "npmVersion": "11.4.2"
+    },
+    "scope": {
+      "description": "Automated QA placeholder for vibe coding workspace",
+      "limitations": [
+        "Full platform deployment and browser-based validation unavailable in container",
+        "No access to production APIs or collaboration backends",
+        "Playwright/Lighthouse tooling not installed in environment"
+      ]
+    }
+  },
+  "executedChecks": [
+    {
+      "name": "TypeScript type check",
+      "command": "npm run check",
+      "status": "cancelled",
+      "details": "Command exceeded practical execution time and was manually terminated to avoid hanging the automation pipeline."
+    }
+  ],
+  "manualReview": {
+    "summary": "Comprehensive UI automation, link crawling, and backend verification could not be executed due to missing browser/runtime dependencies and lack of a deployed instance within the container.",
+    "recommendedNextSteps": [
+      "Provision a full staging deployment that mirrors production endpoints.",
+      "Install and configure Playwright, Lighthouse, and a broken-link checker within CI.",
+      "Establish seeded workspace data to exercise collaboration and runtime flows."
+    ]
+  },
+  "unresolvedIssues": [
+    {
+      "id": "qa-env-001",
+      "title": "Browser automation stack unavailable",
+      "severity": "high",
+      "recommendedFix": "Extend CI image with Playwright browsers and headless Chrome to allow crawling and UI verification."
+    },
+    {
+      "id": "qa-env-002",
+      "title": "Backend connectivity not validated",
+      "severity": "critical",
+      "recommendedFix": "Connect container to representative backend services or provide service mocks for automated verification."
+    }
+  ],
+  "attachments": [],
+  "notes": "This report documents the current limitations blocking a full end-to-end QA pass. No application code changes were made in this run."
+}

--- a/reports/full-QA-report-20251019T125605Z.md
+++ b/reports/full-QA-report-20251019T125605Z.md
@@ -1,0 +1,29 @@
+# Full QA Report – 19 Oct 2025 12:56 UTC
+
+## Overview
+- **Environment**: OpenAI container (Node v22.19.0 / npm 11.4.2)
+- **Scope**: Attempted automated QA for the vibe coding workspace (Replit-style platform)
+- **Status**: Blocked – critical tooling and deployment gaps prevented end-to-end execution.
+
+## Attempted Automation
+| Check | Command | Result | Notes |
+| --- | --- | --- | --- |
+| TypeScript type check | `npm run check` | Cancelled | TypeScript compilation hung for several minutes and was manually interrupted to keep the session responsive. |
+
+## Blockers
+1. **Browser automation stack unavailable** – Playwright/Lighthouse binaries are not installed, preventing UI crawl, screenshot capture, or Lighthouse audits.
+2. **No deploy target or backend connectivity** – Container lacks access to live API services, so workspace sessions, collaboration, and runtime evaluations cannot run.
+3. **Static assets and routes unserved** – Without a running build, link integrity checks cannot resolve application routes.
+
+## Recommended Remediation
+1. Provision a staging deployment that mirrors production services and credentials.
+2. Extend CI/CD images with Playwright browsers, Lighthouse CLI, and a link checker.
+3. Seed collaboration workspaces and runtimes with test data to verify live editing and execution flows.
+
+## Next Steps
+- Re-run the QA suite once the environment includes the required browser tooling and backend connectivity.
+- Automate the workflow through GitHub Actions or n8n with scheduled runs and artifact publishing (JSON/Markdown/PDF).
+- Capture baseline performance metrics (Lighthouse) after deployment access is available.
+
+## Attachments
+_No screenshots or PDFs were produced during this run._


### PR DESCRIPTION
## Summary
- add a JSON QA report capturing the current environment details and blockers preventing end-to-end automation
- add a companion Markdown summary outlining recommended remediation steps for future QA runs

## Testing
- npm run check *(cancelled: hung during TypeScript compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68f4dfb2ae9083209beedfe46285573b