### PR TITLE
Fix ECodeLogo size handling

### DIFF
--- a/client/src/components/ECodeLogo.tsx
+++ b/client/src/components/ECodeLogo.tsx
@@ -3,21 +3,24 @@ import { cn } from '@/lib/utils';
 
 interface ECodeLogoProps {
   className?: string;
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'xs' | 'sm' | 'md' | 'lg';
   showText?: boolean;
 }
 
+const sizeMap: Record<NonNullable<ECodeLogoProps['size']>, { icon: string; text: string }> = {
+  xs: { icon: 'h-5 w-5', text: 'text-base' },
+  sm: { icon: 'h-6 w-6', text: 'text-lg' },
+  md: { icon: 'h-8 w-8', text: 'text-xl' },
+  lg: { icon: 'h-10 w-10', text: 'text-2xl' }
+};
+
 export function ECodeLogo({ className, size = 'md', showText = true }: ECodeLogoProps) {
-  const sizes = {
-    sm: { icon: 'h-6 w-6', text: 'text-lg' },
-    md: { icon: 'h-8 w-8', text: 'text-xl' },
-    lg: { icon: 'h-10 w-10', text: 'text-2xl' }
-  };
+  const resolvedSize = sizeMap[size] ?? sizeMap.md;
 
   return (
     <div className={cn('flex items-center gap-2', className)}>
       <svg
-        className={sizes[size].icon}
+        className={resolvedSize.icon}
         viewBox="0 0 40 40"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
@@ -51,9 +54,9 @@ export function ECodeLogo({ className, size = 'md', showText = true }: ECodeLogo
           </linearGradient>
         </defs>
       </svg>
-      
+
       {showText && (
-        <span className={cn('font-bold', sizes[size].text)}>
+        <span className={cn('font-bold', resolvedSize.text)}>
           E-Code
         </span>
       )}


### PR DESCRIPTION
## Summary
- extend `ECodeLogo` to support an `xs` size option used in the footer
- add a default fallback when an unknown size is provided to prevent runtime errors

## Testing
- npm run test *(fails: missing test setup module)*

------
https://chatgpt.com/codex/tasks/task_e_68f4de6381e483208ca146bbb9214d54