### PR TITLE
Fix project workspace to use string project IDs

### DIFF
--- a/client/src/pages/EditorPage.tsx
+++ b/client/src/pages/EditorPage.tsx
@@ -55,8 +55,9 @@ export default function EditorPage() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   
-  // Parse project ID
-  const projectIdNum = projectId ? parseInt(projectId) : 0;
+  // Preserve project ID as string (UUID compatible)
+  const projectIdValue = projectId ?? '';
+  const hasProjectId = projectIdValue.length > 0;
   
   // Get project details
   const { 
@@ -64,12 +65,13 @@ export default function EditorPage() {
     isLoading: isLoadingProject,
     error: projectError,
   } = useQuery({
-    queryKey: ['/api/projects', projectIdNum],
+    queryKey: ['/api/projects', projectIdValue],
     queryFn: async () => {
-      const res = await apiRequest('GET', `/api/user/projects/${projectIdNum}`);
+      if (!hasProjectId) throw new Error('Missing project id');
+      const res = await apiRequest('GET', `/api/projects/${projectIdValue}`);
       return res.json();
     },
-    enabled: !!projectIdNum && !!user,
+    enabled: hasProjectId && !!user,
   });
   
   // Get project files
@@ -78,12 +80,13 @@ export default function EditorPage() {
     isLoading: isLoadingFiles,
     error: filesError,
   } = useQuery<File[]>({
-    queryKey: ['/api/files', projectIdNum],
+    queryKey: ['/api/files', projectIdValue],
     queryFn: async () => {
-      const res = await apiRequest('GET', `/api/files/${projectIdNum}`);
+      if (!hasProjectId) throw new Error('Missing project id');
+      const res = await apiRequest('GET', `/api/files/${projectIdValue}`);
       return res.json();
     },
-    enabled: !!projectIdNum && !!user,
+    enabled: hasProjectId && !!user,
   });
   
   // Update file content mutation
@@ -94,8 +97,7 @@ export default function EditorPage() {
     },
     onSuccess: (data) => {
       if (projectId) {
-        const projectIdNum = parseInt(projectId);
-        queryClient.invalidateQueries({ queryKey: ['/api/files', projectIdNum] });
+        queryClient.invalidateQueries({ queryKey: ['/api/files', projectId] });
       }
     },
     onError: (error: Error) => {
@@ -110,7 +112,7 @@ export default function EditorPage() {
   // Create file mutation
   const createFileMutation = useMutation({
     mutationFn: async ({ name, isFolder, parentId }: { name: string, isFolder: boolean, parentId?: number | null }) => {
-      const res = await apiRequest('POST', `/api/files/${projectId}`, {
+      const res = await apiRequest('POST', `/api/files/${projectIdValue}`, {
         name,
         isFolder,
         parentId: parentId || null,
@@ -120,8 +122,7 @@ export default function EditorPage() {
     },
     onSuccess: (data) => {
       if (projectId) {
-        const projectIdNum = parseInt(projectId);
-        queryClient.invalidateQueries({ queryKey: ['/api/files', projectIdNum] });
+        queryClient.invalidateQueries({ queryKey: ['/api/files', projectId] });
       }
       toast({
         title: 'File created',
@@ -145,8 +146,7 @@ export default function EditorPage() {
     },
     onSuccess: () => {
       if (projectId) {
-        const projectIdNum = parseInt(projectId);
-        queryClient.invalidateQueries({ queryKey: ['/api/files', projectIdNum] });
+        queryClient.invalidateQueries({ queryKey: ['/api/files', projectId] });
       }
       toast({
         title: 'File deleted',
@@ -294,7 +294,7 @@ export default function EditorPage() {
           
           {/* Run button - E-Code style */}
           <RunButton 
-            projectId={projectIdNum} 
+            projectId={projectIdValue} 
             language={project?.language || 'javascript'}
             onRunning={(running, execId) => {
               setIsProjectRunning(running);
@@ -311,7 +311,7 @@ export default function EditorPage() {
           {/* Collaboration Presence - Hidden on mobile */}
           {user && !isMobile && (
             <CollaborationPresence 
-              projectId={projectIdNum} 
+              projectId={projectIdValue} 
               currentUserId={user.id}
               compact={true}
               className="mr-2"
@@ -370,7 +370,7 @@ export default function EditorPage() {
               onFileCreate={handleFileCreate}
               onFileDelete={handleFileDelete}
               projectName={project?.name}
-              projectId={projectIdNum}
+              projectId={projectIdValue}
             />
           }
           codeEditor={
@@ -382,12 +382,12 @@ export default function EditorPage() {
           }
           terminal={
             <ResponsiveTerminal 
-              projectId={projectIdNum}
+              projectId={projectIdValue}
             />
           }
           preview={
             <ResponsiveWebPreview 
-              projectId={projectIdNum} 
+              projectId={projectIdValue} 
               isRunning={isProjectRunning}
             />
           }
@@ -395,7 +395,7 @@ export default function EditorPage() {
           isRunning={isProjectRunning}
           onRun={() => {
             // Handle run action - project runs automatically
-            console.log('Running project', projectIdNum);
+            console.log('Running project', projectIdValue);
           }}
         />
       ) : (
@@ -408,7 +408,7 @@ export default function EditorPage() {
               onFileCreate={handleFileCreate}
               onFileDelete={handleFileDelete}
               projectName={project?.name}
-              projectId={projectIdNum}
+              projectId={projectIdValue}
             />
           }
           centerPanel={
@@ -419,50 +419,50 @@ export default function EditorPage() {
             />
           }
           bottomPanel={
-            <ResponsiveTerminal projectId={projectIdNum} />
+            <ResponsiveTerminal projectId={projectIdValue} />
           }
           rightPanels={[
             {
               id: 'console',
               title: 'Console',
               icon: <TerminalIcon className="h-3 w-3" />,
-              content: <ReplitConsole projectId={projectIdNum} isRunning={isProjectRunning} executionId={executionId} />
+              content: <ReplitConsole projectId={projectIdValue} isRunning={isProjectRunning} executionId={executionId} />
             },
             {
               id: 'preview',
               title: 'Webview',
               icon: <Globe className="h-3 w-3" />,
-              content: <ResponsiveWebPreview projectId={projectIdNum} isRunning={isProjectRunning} />
+              content: <ResponsiveWebPreview projectId={projectIdValue} isRunning={isProjectRunning} />
             },
             {
               id: 'database',
               title: 'Database',
               icon: <Database className="h-3 w-3" />,
-              content: <DatabaseBrowser projectId={projectIdNum.toString()} />
+              content: <DatabaseBrowser projectId={projectIdValue} />
             },
             {
               id: 'packages',
               title: 'Packages',
               icon: <PackageIcon className="h-3 w-3" />,
-              content: <PackageViewer projectId={projectIdNum.toString()} />
+              content: <PackageViewer projectId={projectIdValue} />
             },
             {
               id: 'debugger',
               title: 'Debugger',
               icon: <Bug className="h-3 w-3" />,
-              content: <DebuggerPanel projectId={projectIdNum.toString()} />
+              content: <DebuggerPanel projectId={projectIdValue} />
             },
             {
               id: 'deployment',
               title: 'Deploy',
               icon: <Rocket className="h-3 w-3" />,
-              content: <DeploymentManager projectId={projectIdNum} />
+              content: <DeploymentManager projectId={projectIdValue} />
             },
             {
               id: 'tests',
               title: 'Tests',
               icon: <Beaker className="h-3 w-3" />,
-              content: <TestRunner projectId={projectIdNum.toString()} />
+              content: <TestRunner projectId={projectIdValue} />
             }
           ]}
           defaultRightPanel="console"
@@ -472,7 +472,7 @@ export default function EditorPage() {
       {/* Global Search Dialog */}
       {showGlobalSearch && (
         <GlobalSearch
-          projectId={projectIdNum}
+          projectId={projectIdValue}
           isOpen={showGlobalSearch}
           onClose={() => setShowGlobalSearch(false)}
           onFileSelect={(file) => {

--- a/server/realtime/realtime-service.ts
+++ b/server/realtime/realtime-service.ts
@@ -9,7 +9,7 @@ const logger = createLogger('realtime-service');
 
 export interface RealtimeEvent {
   type: 'file-update' | 'file-create' | 'file-delete' | 'build-log' | 'deploy-log' | 'terminal-output' | 'preview-update' | 'collaboration' | 'notification';
-  projectId: number;
+  projectId: string;
   data: any;
   timestamp: Date;
   userId?: number;
@@ -17,7 +17,7 @@ export interface RealtimeEvent {
 
 export class RealtimeService {
   private io: SocketServer;
-  private projectRooms = new Map<number, Set<string>>(); // projectId -> Set of socket IDs
+  private projectRooms = new Map<string, Set<string>>(); // projectId -> Set of socket IDs
   private userSockets = new Map<number, Set<string>>(); // userId -> Set of socket IDs
   
   constructor(server: HttpServer) {
@@ -54,7 +54,7 @@ export class RealtimeService {
     
     this.io.on('connection', async (socket: Socket) => {
       const userId = socket.data.userId;
-      const projectId = parseInt(socket.data.projectId);
+      const projectId = (socket.data.projectId || '').toString();
       
       logger.info(`User ${userId} connected to project ${projectId}`);
       
@@ -71,7 +71,7 @@ export class RealtimeService {
           this.projectRooms.set(projectId, new Set());
         }
         this.projectRooms.get(projectId)!.add(socket.id);
-        
+
         // Send initial project state
         await this.sendProjectState(socket, projectId);
       }
@@ -104,7 +104,7 @@ export class RealtimeService {
       socket.on('disconnect', () => {
         // Clean up
         const userId = socket.data.userId;
-        const projectId = socket.data.projectId;
+        const projectId = (socket.data.projectId || '').toString();
         
         if (userId && this.userSockets.has(userId)) {
           this.userSockets.get(userId)!.delete(socket.id);
@@ -125,7 +125,7 @@ export class RealtimeService {
     });
   }
   
-  private async sendProjectState(socket: Socket, projectId: number) {
+  private async sendProjectState(socket: Socket, projectId: string) {
     try {
       // Send current project files
       const files = await storage.getFilesByProjectId(projectId);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -583,25 +583,24 @@ const ensureProjectAccess = async (req: Request, res: Response, next: NextFuncti
   }
   
   const userId = req.user!.id;
-  const projectId = parseInt(req.params.projectId || req.params.id);
-  
-  // Check if projectId is valid
-  if (isNaN(projectId)) {
-    console.log('[POLYGLOT] Invalid project ID:', req.params.projectId || req.params.id);
-    return res.status(400).json({ 
+  const projectId = (req.params.projectId || req.params.id || '').toString();
+
+  if (!projectId) {
+    console.log('[POLYGLOT] Missing project ID');
+    return res.status(400).json({
       message: "Invalid project ID",
-      code: "INVALID_PROJECT_ID" 
+      code: "INVALID_PROJECT_ID"
     });
   }
-  
+
   // Get the project
   const project = await storage.getProject(projectId);
   if (!project) {
     console.log('[POLYGLOT] Project not found:', projectId);
-    return res.status(404).json({ 
+    return res.status(404).json({
       message: "Project not found",
       code: "PROJECT_NOT_FOUND",
-      projectId 
+      projectId
     });
   }
   
@@ -870,7 +869,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.post('/api/projects/:projectId/gpu/provision', ensureAuthenticated, ensureProjectAccess, async (req, res) => {
     try {
-      const projectId = parseInt(req.params.projectId);
+      const projectId = req.params.projectId;
       const { gpuType, region } = req.body;
       
       const { getGpuService } = await import('./services/gpu-service');
@@ -886,7 +885,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.get('/api/projects/:projectId/gpu/instances', ensureAuthenticated, ensureProjectAccess, async (req, res) => {
     try {
-      const projectId = parseInt(req.params.projectId);
+      const projectId = req.params.projectId;
       const instances = await storage.getProjectGpuInstances(projectId);
       res.json(instances);
     } catch (error) {
@@ -3924,7 +3923,7 @@ Application will be available at http://localhost:3000
 
   app.get('/api/projects/:id', ensureAuthenticated, ensureProjectAccess, async (req, res) => {
     try {
-      const projectId = parseInt(req.params.id);
+      const projectId = req.params.id;
       const project = await storage.getProject(projectId);
       
       if (!project) {
@@ -4204,7 +4203,7 @@ Application will be available at http://localhost:3000
 
   app.delete('/api/projects/:id', ensureAuthenticated, ensureProjectAccess, async (req, res) => {
     try {
-      const projectId = parseInt(req.params.id);
+      const projectId = req.params.id;
       await storage.deleteProject(projectId);
       res.status(200).json({ success: true });
     } catch (error) {
@@ -4216,7 +4215,7 @@ Application will be available at http://localhost:3000
   // API Routes for Project Files - ROUTE THROUGH GO SERVICE
   app.get('/api/projects/:id/files', ensureAuthenticated, ensureProjectAccess, async (req, res) => {
     try {
-      const projectId = parseInt(req.params.id);
+      const projectId = req.params.id;
       
       // Use TypeScript for database operations
       const files = await storage.getFilesByProjectId(projectId);
@@ -4235,9 +4234,9 @@ Application will be available at http://localhost:3000
     }
   });
 
-  app.post('/api/projects/:id/files', ensureAuthenticated, ensureProjectAccess, async (req, res) => {
-    try {
-      const projectId = parseInt(req.params.id);
+    app.post('/api/projects/:id/files', ensureAuthenticated, ensureProjectAccess, async (req, res) => {
+      try {
+        const projectId = req.params.id;
       
       // Validate file name
       if (!req.body.name || req.body.name.trim() === '') {
@@ -4274,7 +4273,7 @@ Application will be available at http://localhost:3000
       }
       
       // Check for duplicate file names in the same directory
-      const existingFiles = await storage.getFilesByProjectId(projectId);
+        const existingFiles = await storage.getFilesByProjectId(projectId);
       const duplicate = existingFiles.find(f => 
         f.name === req.body.name && 
         f.parentId === parentId
@@ -4298,7 +4297,7 @@ Application will be available at http://localhost:3000
       const fileData = {
         name: req.body.name.trim(),
         path: filePath,
-        projectId: projectId,
+          projectId: projectId,
         content: req.body.content || '',
         isDirectory: req.body.isFolder || false
       };
@@ -4320,38 +4319,41 @@ Application will be available at http://localhost:3000
   // Route pour récupérer les fichiers d'un projet (compatible avec le client)
   app.get('/api/files/:id', ensureAuthenticated, async (req, res) => {
     try {
-      const id = parseInt(req.params.id);
-      
-      // Check if this is a project ID (fetching all files) or a file ID (fetching single file)
-      // First try as project ID
-      const project = await storage.getProject(id);
+      const idParam = req.params.id;
+
+      // First attempt to treat the parameter as a project ID (string UUID)
+      const project = await storage.getProject(idParam);
       if (project) {
-        // This is a project ID - return all files
         if (project.ownerId !== req.user!.id) {
-          const isCollaborator = await storage.isProjectCollaborator(id, req.user!.id);
+          const isCollaborator = await storage.isProjectCollaborator(idParam, req.user!.id);
           if (!isCollaborator) {
             return res.status(403).json({ error: 'Access denied' });
           }
         }
-        
-        const files = await storage.getFilesByProjectId(id);
+
+        const files = await storage.getFilesByProjectId(idParam);
         // Add isFolder field for frontend compatibility
         const filesWithFolder = files.map(file => ({
           ...file,
           isFolder: file.isDirectory || file.isFolder || false
         }));
-        
+
         // Return array directly (not wrapped in object) as client expects
         return res.json(filesWithFolder);
       }
-      
-      // If not a project, try as a file ID
-      const file = await storage.getFile(id);
-      
+
+      // If not a project, try as a file ID (numeric)
+      const fileId = parseInt(idParam, 10);
+      if (isNaN(fileId)) {
+        return res.status(404).json({ error: 'File or project not found' });
+      }
+
+      const file = await storage.getFile(fileId);
+
       if (!file) {
         return res.status(404).json({ error: 'File or project not found' });
       }
-      
+
       // Ensure user has access to the project this file belongs to
       const fileProject = await storage.getProject(file.projectId);
       if (!fileProject || fileProject.ownerId !== req.user!.id) {
@@ -4429,7 +4431,7 @@ Application will be available at http://localhost:3000
   // Route pour créer un fichier (compatible avec le client qui utilise POST /api/files/${projectId})
   app.post('/api/files/:projectId', ensureAuthenticated, async (req, res) => {
     try {
-      const projectId = parseInt(req.params.projectId);
+      const projectId = req.params.projectId;
       
       // Vérifier l'accès au projet
       const project = await storage.getProject(projectId);
@@ -4449,7 +4451,7 @@ Application will be available at http://localhost:3000
         name: req.body.name || 'untitled',
         path: req.body.path || '/',
         content: req.body.content || '',
-        projectId: projectId,
+        projectId,
         parentId: req.body.parentId || null,
         isDirectory: req.body.isDirectory || req.body.isFolder || false,
         isFolder: req.body.isFolder || req.body.isDirectory || false

--- a/server/terminal.ts
+++ b/server/terminal.ts
@@ -20,7 +20,7 @@ containerExecutor.init().catch(err => {
 });
 
 // Map to store terminal sessions by projectId
-const terminalSessions = new Map<number, {
+const terminalSessions = new Map<string, {
   sessionId: string;
   clients: Set<WebSocket>;
   commandHistory: string[];
@@ -44,15 +44,15 @@ export function setupTerminalWebsocket(server: Server) {
     try {
       // Get the project ID from query params
       const url = new URL(req.url || '', `http://${req.headers.host}`);
-      const projectId = parseInt(url.searchParams.get('projectId') || '');
-      
-      if (isNaN(projectId)) {
+      const projectId = url.searchParams.get('projectId') || '';
+
+      if (!projectId) {
         ws.close(1008, 'Missing or invalid projectId');
         return;
       }
-      
+
       logger.info(`Terminal connection established for project ${projectId}`);
-      
+
       // Create terminal session if it doesn't exist
       if (!terminalSessions.has(projectId)) {
         terminalSessions.set(projectId, {
@@ -64,11 +64,11 @@ export function setupTerminalWebsocket(server: Server) {
             'npm', 'node', 'python', 'python3', 'git', 'curl', 'wget',
             'yarn', 'clear', 'exit', 'kill', 'ps', 'cp', 'mv', 'rm'
           ],
-          currentDirectory: `/project${projectId}`,
+          currentDirectory: `/project/${projectId}`,
           outputBuffer: ''
         });
       }
-      
+
       const terminalSession = terminalSessions.get(projectId)!;
       terminalSession.clients.add(ws);
       
@@ -209,7 +209,7 @@ export function setupTerminalWebsocket(server: Server) {
 }
 
 // Start a terminal process for a project
-async function startProcess(projectId: number, terminalInfo: { 
+async function startProcess(projectId: string, terminalInfo: { 
   process: ChildProcess | null, 
   clients: Set<WebSocket>,
   commandHistory: string[],
@@ -230,7 +230,7 @@ async function startProcess(projectId: number, terminalInfo: {
     }
     
     // Get project files to determine the working directory
-    const files = await storage.getFilesByProject(projectId);
+    const files = await storage.getFilesByProjectId(projectId);
     
     // Create a temporary directory for the project
     const projectDir = await createProjectDir(project, files);
@@ -307,7 +307,7 @@ async function startProcess(projectId: number, terminalInfo: {
 }
 
 // Stop a terminal process
-function stopProcess(projectId: number, terminalInfo: { 
+function stopProcess(projectId: string, terminalInfo: { 
   process: ChildProcess | null, 
   clients: Set<WebSocket>,
   commandHistory: string[],
@@ -349,7 +349,7 @@ function broadcastToClients(clients: Set<WebSocket>, message: TerminalMessage): 
 }
 
 // Create a temporary project directory with all project files
-async function createProjectDir(project: { id: number }, files: File[]): Promise<string> {
+async function createProjectDir(project: { id: string }, files: File[]): Promise<string> {
   const projectDir = path.join(os.tmpdir(), `plot-terminal-${project.id}`);
   
   try {
@@ -377,7 +377,7 @@ async function createProjectDir(project: { id: number }, files: File[]): Promise
 }
 
 // Execute a command using the container executor
-async function executeCommand(projectId: number, command: string) {
+async function executeCommand(projectId: string, command: string) {
   const session = terminalSessions.get(projectId);
   if (!session) return;
   
@@ -458,7 +458,7 @@ async function executeCommand(projectId: number, command: string) {
 }
 
 // Broadcast message to all connected clients for a project
-function broadcast(projectId: number, message: string) {
+function broadcast(projectId: string, message: string) {
   const session = terminalSessions.get(projectId);
   if (!session) return;
   


### PR DESCRIPTION
## Summary
- keep the workspace project identifier as the raw string in the editor and query the correct /api/projects/:id endpoint
- update project and file routes plus middleware to accept UUID strings instead of parsing integers
- update realtime and terminal services to treat project IDs as strings so sockets and containers work with UUIDs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4df6909b88320b14fd350a8c9d50b