### PR TITLE
Restore custom test harness

### DIFF
--- a/test/ai-ux-features.test.ts
+++ b/test/ai-ux-features.test.ts
@@ -1,0 +1,5 @@
+import { testRunner } from './setup/test-runner';
+
+testRunner.registerSuite('AI UX Features', {
+  tests: [],
+});

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -1,0 +1,5 @@
+import { testRunner } from './setup/test-runner';
+
+testRunner.registerSuite('Security', {
+  tests: [],
+});

--- a/test/setup/globals.ts
+++ b/test/setup/globals.ts
@@ -1,0 +1,126 @@
+import util from 'node:util';
+
+type Primitive = string | number | boolean | bigint | symbol | null | undefined;
+
+type Expectation<T> = {
+  toBe(expected: T): void;
+  toEqual(expected: unknown): void;
+  toBeDefined(): void;
+  toBeTruthy(): void;
+  toBeFalsy(): void;
+  toContain(expected: unknown): void;
+};
+
+const isPrimitive = (value: unknown): value is Primitive =>
+  (value !== Object(value)) || typeof value === 'symbol';
+
+const deepEqual = (a: unknown, b: unknown, seen = new WeakMap<object, object>()): boolean => {
+  if (Object.is(a, b)) {
+    return true;
+  }
+
+  if (typeof a !== typeof b) {
+    return false;
+  }
+
+  if (a === null || b === null) {
+    return a === b;
+  }
+
+  if (isPrimitive(a) || isPrimitive(b)) {
+    return a === b;
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) {
+      return false;
+    }
+
+    return a.every((item, index) => deepEqual(item, b[index], seen));
+  }
+
+  if (typeof a === 'object' && typeof b === 'object') {
+    const objA = a as Record<string | symbol, unknown>;
+    const objB = b as Record<string | symbol, unknown>;
+
+    if (seen.get(objA) === objB) {
+      return true;
+    }
+    seen.set(objA, objB);
+
+    const keysA = Reflect.ownKeys(objA);
+    const keysB = Reflect.ownKeys(objB);
+
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+
+    return keysA.every((key) => deepEqual(objA[key], objB[key], seen));
+  }
+
+  return false;
+};
+
+function createExpectation<T>(actual: T): Expectation<T> {
+  return {
+    toBe(expected) {
+      if (!Object.is(actual, expected)) {
+        throw new Error(`Expected ${formatValue(actual)} to be ${formatValue(expected)}`);
+      }
+    },
+    toEqual(expected) {
+      if (!deepEqual(actual, expected)) {
+        throw new Error(`Expected ${formatValue(actual)} to equal ${formatValue(expected)}`);
+      }
+    },
+    toBeDefined() {
+      if (actual === undefined) {
+        throw new Error('Expected value to be defined');
+      }
+    },
+    toBeTruthy() {
+      if (!actual) {
+        throw new Error(`Expected ${formatValue(actual)} to be truthy`);
+      }
+    },
+    toBeFalsy() {
+      if (actual) {
+        throw new Error(`Expected ${formatValue(actual)} to be falsy`);
+      }
+    },
+    toContain(expected) {
+      if (typeof (actual as unknown as { includes?: (item: unknown) => boolean }).includes === 'function') {
+        if (!(actual as unknown as { includes: (item: unknown) => boolean }).includes(expected)) {
+          throw new Error(`Expected ${formatValue(actual)} to contain ${formatValue(expected)}`);
+        }
+        return;
+      }
+
+      if (Array.isArray(actual)) {
+        if (!actual.some((item) => deepEqual(item, expected))) {
+          throw new Error(`Expected ${formatValue(actual)} to contain ${formatValue(expected)}`);
+        }
+        return;
+      }
+
+      throw new Error('toContain matcher requires an array or value supporting includes');
+    },
+  };
+}
+
+const formatValue = (value: unknown): string =>
+  typeof value === 'string' ? `'${value}'` : util.inspect(value, { depth: 4, colors: false });
+
+export type ExpectFn = <T>(actual: T) => Expectation<T>;
+
+export const setupTestGlobals = (): void => {
+  const expectFn: ExpectFn = (actual) => createExpectation(actual);
+
+  Object.assign(globalThis, {
+    expect: expectFn,
+  });
+};
+
+export type GlobalExpect = typeof globalThis & {
+  expect: ExpectFn;
+};

--- a/test/setup/test-runner.ts
+++ b/test/setup/test-runner.ts
@@ -1,0 +1,120 @@
+import { performance } from 'node:perf_hooks';
+
+type MaybePromise<T> = T | Promise<T>;
+
+export type TestCase = {
+  name: string;
+  fn: () => MaybePromise<void>;
+  skip?: boolean;
+  only?: boolean;
+};
+
+export type SuiteLifecycle = {
+  beforeAll?: () => MaybePromise<void>;
+  afterAll?: () => MaybePromise<void>;
+  beforeEach?: () => MaybePromise<void>;
+  afterEach?: () => MaybePromise<void>;
+};
+
+export type TestSuite = SuiteLifecycle & {
+  tests: TestCase[];
+};
+
+type RegisteredSuite = {
+  name: string;
+  suite: TestSuite;
+};
+
+const registeredSuites: RegisteredSuite[] = [];
+
+const matchesPattern = (name: string, pattern?: string): boolean => {
+  if (!pattern) {
+    return true;
+  }
+
+  const normalized = pattern.trim().toLowerCase();
+  if (!normalized) {
+    return true;
+  }
+
+  return name.toLowerCase().includes(normalized);
+};
+
+const hasFocusedTests = (): boolean =>
+  registeredSuites.some((entry) => entry.suite.tests.some((test) => test.only));
+
+const formatDuration = (ms: number): string => `${ms.toFixed(0)}ms`;
+
+export const testRunner = {
+  registerSuite(name: string, suite: TestSuite): void {
+    registeredSuites.push({ name, suite });
+  },
+
+  async run(pattern?: string): Promise<{ failed: number; passed: number }> {
+    let failed = 0;
+    let passed = 0;
+    const focused = hasFocusedTests();
+
+    for (const { name: suiteName, suite } of registeredSuites) {
+      const tests = suite.tests.filter((test) => {
+        if (focused && !test.only) {
+          return false;
+        }
+
+        if (test.skip) {
+          return false;
+        }
+
+        return matchesPattern(`${suiteName} ${test.name}`, pattern);
+      });
+
+      if (tests.length === 0) {
+        continue;
+      }
+
+      console.log(`\nSuite: ${suiteName}`);
+
+      if (suite.beforeAll) {
+        await suite.beforeAll();
+      }
+
+      for (const test of tests) {
+        if (suite.beforeEach) {
+          await suite.beforeEach();
+        }
+
+        const started = performance.now();
+
+        try {
+          await test.fn();
+          passed += 1;
+          const duration = performance.now() - started;
+          console.log(`  ✓ ${test.name} (${formatDuration(duration)})`);
+        } catch (error) {
+          failed += 1;
+          const duration = performance.now() - started;
+          console.error(`  ✗ ${test.name} (${formatDuration(duration)})`);
+          if (error instanceof Error) {
+            console.error(error.stack ?? error.message);
+          } else {
+            console.error(error);
+          }
+        }
+
+        if (suite.afterEach) {
+          await suite.afterEach();
+        }
+      }
+
+      if (suite.afterAll) {
+        await suite.afterAll();
+      }
+    }
+
+    console.log(`\nTest Results: ${passed} passed, ${failed} failed`);
+
+    return { failed, passed };
+  },
+};
+
+export type TestRunner = typeof testRunner;


### PR DESCRIPTION
## Summary
- add a lightweight assertion helper and register it via setupTestGlobals
- implement a custom test runner with support for suite lifecycle hooks and filtering
- provide placeholder suites for missing security and AI UX feature tests so imports succeed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f4e318442c8320abc4fae08c46f3b0