### PR TITLE
Improve test runner filtering and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ For Google Cloud reference architectures and scaling strategies, see [`docs/oper
 
 ## Testing & Quality Gates
 
-- `npm test` – Runs integration and smoke tests from `test/`.
+- `npm test` – Runs integration and smoke tests from `test/`, including the security middleware and AI UX feature suites.
+- `npm test -- test/security.test.ts` – Filters execution to the security hardening scenarios using the lightweight harness.
+- `npm test -- test/ai-ux-features.test.ts` – Focuses on AI UX feature flag coverage and environment overrides.
 - `npm run typecheck` – Validates shared TypeScript contracts.
 - `npm run typecheck:full` – Performs exhaustive client + server type validation (requires ~8 GB RAM).
 - `npm run build` – Bundles the client and server for production deployments.

--- a/docs/AI_UX_FEATURES.md
+++ b/docs/AI_UX_FEATURES.md
@@ -113,7 +113,7 @@ All features include comprehensive telemetry tracking:
 Run the test suite:
 
 ```bash
-npm test test/ai-ux-features.test.ts
+npm test -- test/ai-ux-features.test.ts
 ```
 
 ## User Guide

--- a/test/ai-ux-features.test.ts
+++ b/test/ai-ux-features.test.ts
@@ -1,0 +1,88 @@
+import { testRunner } from './setup/test-runner';
+
+const ORIGINAL_ENV = { ...process.env };
+
+testRunner.registerSuite('AI UX Feature Flags', {
+  afterAll: () => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in ORIGINAL_ENV)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, ORIGINAL_ENV);
+  },
+  tests: [
+    {
+      name: 'defaultFeatureFlags disable all AI UX toggles',
+      fn: async () => {
+        const module = await import('../server/config/feature-flags.ts?base');
+        const { defaultFeatureFlags } = module;
+
+        expect(defaultFeatureFlags.aiUx.improvePrompt).toBe(false);
+        expect(defaultFeatureFlags.aiUx.extendedThinking).toBe(false);
+        expect(defaultFeatureFlags.aiUx.highPowerMode).toBe(false);
+        expect(defaultFeatureFlags.aiUx.progressTab).toBe(false);
+        expect(defaultFeatureFlags.aiUx.pauseResume).toBe(false);
+      },
+    },
+    {
+      name: 'getFeatureFlags reads environment overrides',
+      fn: async () => {
+        process.env.FEATURE_AI_UX_IMPROVE_PROMPT = 'true';
+        process.env.FEATURE_AI_UX_EXTENDED_THINKING = 'true';
+        process.env.FEATURE_AI_UX_HIGH_POWER_MODE = 'true';
+        process.env.FEATURE_AI_UX_PROGRESS_TAB = 'false';
+        process.env.FEATURE_AI_UX_PAUSE_RESUME = 'true';
+
+        const module = await import(`../server/config/feature-flags.ts?env=${Date.now()}`);
+        const flags = module.getFeatureFlags();
+
+        expect(flags.aiUx.improvePrompt).toBe(true);
+        expect(flags.aiUx.extendedThinking).toBe(true);
+        expect(flags.aiUx.highPowerMode).toBe(true);
+        expect(flags.aiUx.progressTab).toBe(false);
+        expect(flags.aiUx.pauseResume).toBe(true);
+      },
+    },
+    {
+      name: 'featureFlags snapshot reflects current environment on import',
+      fn: async () => {
+        process.env.FEATURE_AI_UX_IMPROVE_PROMPT = 'true';
+        process.env.FEATURE_AI_UX_EXTENDED_THINKING = 'false';
+        process.env.FEATURE_AI_UX_HIGH_POWER_MODE = 'true';
+        process.env.FEATURE_AI_UX_PROGRESS_TAB = 'true';
+        process.env.FEATURE_AI_UX_PAUSE_RESUME = 'false';
+
+        const module = await import(`../server/config/feature-flags.ts?snapshot=${Date.now()}`);
+        const { featureFlags } = module;
+
+        expect(featureFlags.aiUx).toMatchObject({
+          improvePrompt: true,
+          extendedThinking: false,
+          highPowerMode: true,
+          progressTab: true,
+          pauseResume: false,
+        });
+      },
+    },
+    {
+      name: 'getFeatureFlags falls back to false when env not provided',
+      fn: async () => {
+        delete process.env.FEATURE_AI_UX_IMPROVE_PROMPT;
+        delete process.env.FEATURE_AI_UX_EXTENDED_THINKING;
+        delete process.env.FEATURE_AI_UX_HIGH_POWER_MODE;
+        delete process.env.FEATURE_AI_UX_PROGRESS_TAB;
+        delete process.env.FEATURE_AI_UX_PAUSE_RESUME;
+
+        const module = await import(`../server/config/feature-flags.ts?fallback=${Date.now()}`);
+        const flags = module.getFeatureFlags();
+
+        expect(flags.aiUx.improvePrompt).toBe(false);
+        expect(flags.aiUx.extendedThinking).toBe(false);
+        expect(flags.aiUx.highPowerMode).toBe(false);
+        expect(flags.aiUx.progressTab).toBe(false);
+        expect(flags.aiUx.pauseResume).toBe(false);
+      },
+    },
+  ],
+});

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -1,0 +1,257 @@
+import { testRunner } from './setup/test-runner';
+import {
+  securityMiddleware,
+  csrfProtection,
+  sanitizeInput,
+  preventSQLInjection,
+  fileUploadSecurity,
+  apiKeyValidation,
+  securityMonitoring,
+  ipSecurity
+} from '../server/middleware/security';
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    setHeader(name: string, value: string) {
+      this.headers[name] = value;
+    },
+  };
+}
+
+testRunner.registerSuite('Security Middleware', {
+  tests: [
+    {
+      name: 'securityMiddleware sets essential headers for API traffic',
+      fn: async () => {
+        const middlewares = securityMiddleware();
+        expect(Array.isArray(middlewares)).toBe(true);
+        expect(middlewares.length >= 2).toBe(true);
+
+        const headerMiddleware = middlewares[1];
+        const req: any = { path: '/api/projects', method: 'POST' };
+        const res = createResponse();
+        let nextCalled = false;
+
+        await headerMiddleware(req, res, () => {
+          nextCalled = true;
+        });
+
+        expect(res.headers['X-Frame-Options']).toBe('DENY');
+        expect(res.headers['X-Content-Type-Options']).toBe('nosniff');
+        expect(res.headers['X-XSS-Protection']).toBe('1; mode=block');
+        expect(res.headers['Referrer-Policy']).toBe('strict-origin-when-cross-origin');
+        expect(res.headers['Permissions-Policy']).toContain('geolocation');
+        expect(res.headers['X-API-Version']).toBe('1.0');
+        expect(res.headers['X-RateLimit-Policy']).toContain('rate-limits');
+        expect(nextCalled).toBe(true);
+      },
+    },
+    {
+      name: 'csrfProtection generates secure tokens and verifies them',
+      fn: () => {
+        const csrf = csrfProtection();
+        const sessionId = 'session-123';
+        const token = csrf.generate(sessionId);
+
+        expect(typeof token).toBe('string');
+        expect(token).toHaveLength(64);
+        expect(csrf.verify(sessionId, token)).toBe(true);
+
+        const invalidToken = token.slice(0, -1) + (token.endsWith('a') ? 'b' : 'a');
+        expect(csrf.verify(sessionId, invalidToken)).toBe(false);
+
+        const originalNow = Date.now;
+        try {
+          Date.now = () => originalNow() + 2 * 60 * 60 * 1000;
+          expect(csrf.verify(sessionId, token)).toBe(false);
+        } finally {
+          Date.now = originalNow;
+        }
+      },
+    },
+    {
+      name: 'sanitizeInput removes common XSS payloads across request data',
+      fn: () => {
+        const req: any = {
+          body: { message: "<script>alert('x')</script><img src='x' onerror=alert(1)>" },
+          query: { q: "javascript:alert('oops')" },
+          params: { id: "<div onclick='steal()'>123</div>" },
+        };
+        const res = createResponse();
+        let nextCalled = false;
+
+        sanitizeInput(req, res, () => {
+          nextCalled = true;
+        });
+
+        expect(req.body.message.includes('<')).toBe(false);
+        expect(req.body.message.toLowerCase().includes('script')).toBe(false);
+        expect(req.body.message.toLowerCase().includes('onerror')).toBe(false);
+        expect(req.query.q.toLowerCase().includes('javascript:')).toBe(false);
+        expect(req.params.id.includes('<')).toBe(false);
+        expect(nextCalled).toBe(true);
+      },
+    },
+    {
+      name: 'preventSQLInjection strips dangerous SQL patterns',
+      fn: () => {
+        const input = "SELECT * FROM users WHERE name = 'admin' OR 1=1; --";
+        const sanitized = preventSQLInjection(input);
+
+        expect(sanitized.toLowerCase().includes('select')).toBe(false);
+        expect(sanitized.includes('--')).toBe(false);
+        expect(sanitized.includes("'")).toBe(false);
+        expect(sanitized.toLowerCase().includes('or')).toBe(false);
+      },
+    },
+    {
+      name: 'fileUploadSecurity validates mime type, size, and extension',
+      fn: () => {
+        const valid = fileUploadSecurity.validateFile({
+          mimetype: 'image/png',
+          size: 1024,
+          originalname: 'avatar.png',
+        } as any);
+        expect(valid).toEqual({ valid: true });
+
+        const badType = fileUploadSecurity.validateFile({
+          mimetype: 'application/x-msdownload',
+          size: 500,
+          originalname: 'malware.exe',
+        } as any);
+        expect(badType.valid).toBe(false);
+        expect(badType.error).toBe('Invalid file type');
+
+        const badSize = fileUploadSecurity.validateFile({
+          mimetype: 'image/jpeg',
+          size: fileUploadSecurity.maxFileSize + 1,
+          originalname: 'photo.jpg',
+        } as any);
+        expect(badSize.valid).toBe(false);
+        expect(badSize.error).toBe('File too large');
+
+        const mismatch = fileUploadSecurity.validateFile({
+          mimetype: 'image/png',
+          size: 200,
+          originalname: 'avatar.jpg',
+        } as any);
+        expect(mismatch.valid).toBe(false);
+        expect(mismatch.error).toBe('File extension mismatch');
+
+        const secureName = fileUploadSecurity.generateSecureFilename('avatar.png');
+        expect(secureName.endsWith('.png')).toBe(true);
+        expect(secureName.split('.')[0].length).toBe(32);
+      },
+    },
+    {
+      name: 'apiKeyValidation enforces presence and minimum length',
+      fn: () => {
+        const res = createResponse();
+        const reqMissing: any = { headers: {} };
+        let nextCalled = false;
+
+        apiKeyValidation(reqMissing, res, () => {
+          nextCalled = true;
+        });
+
+        expect(res.statusCode).toBe(401);
+        expect((res.body as any)?.error).toBe('API key required');
+        expect(nextCalled).toBe(false);
+
+        const resInvalid = createResponse();
+        const reqInvalid: any = { headers: { 'x-api-key': 'short-key' } };
+        apiKeyValidation(reqInvalid, resInvalid, () => {
+          nextCalled = true;
+        });
+        expect(resInvalid.statusCode).toBe(401);
+        expect((resInvalid.body as any)?.error).toBe('Invalid API key');
+
+        const resValid = createResponse();
+        const reqValid: any = { headers: { 'x-api-key': 'a'.repeat(40) } };
+        let validNextCalled = false;
+        apiKeyValidation(reqValid, resValid, () => {
+          validNextCalled = true;
+        });
+        expect(validNextCalled).toBe(true);
+        expect(resValid.statusCode).toBe(200);
+      },
+    },
+    {
+      name: 'ipSecurity blocks blacklisted IPs and restricts admin access',
+      fn: async () => {
+        ipSecurity.blacklist.clear();
+        const originalEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'production';
+        ipSecurity.adminWhitelist = ['10.0.0.1'];
+
+        ipSecurity.blockIp('1.2.3.4', 10);
+        expect(ipSecurity.blacklist.has('1.2.3.4')).toBe(true);
+
+        await new Promise(resolve => setTimeout(resolve, 20));
+        expect(ipSecurity.blacklist.has('1.2.3.4')).toBe(false);
+
+        const resBlocked = createResponse();
+        const reqBlocked: any = { path: '/admin', ip: '9.9.9.9' };
+        let nextCalled = false;
+        ipSecurity.middleware(reqBlocked, resBlocked, () => {
+          nextCalled = true;
+        });
+        expect(resBlocked.statusCode).toBe(403);
+        expect((resBlocked.body as any)?.error).toBe('Admin access restricted');
+        expect(nextCalled).toBe(false);
+
+        const resAllowed = createResponse();
+        const reqAllowed: any = { path: '/admin/settings', ip: '10.0.0.1' };
+        let allowedNext = false;
+        ipSecurity.middleware(reqAllowed, resAllowed, () => {
+          allowedNext = true;
+        });
+        expect(allowedNext).toBe(true);
+
+        process.env.NODE_ENV = originalEnv;
+      },
+    },
+    {
+      name: 'securityMonitoring flags suspicious payloads',
+      fn: () => {
+        const req: any = {
+          path: '/api/projects',
+          method: 'POST',
+          ip: '8.8.8.8',
+          query: {},
+          body: { input: '<script>alert(1)</script>' },
+          get: () => 'test-agent',
+        };
+        const res = createResponse();
+        let nextCalled = false;
+        let warnCalled = false;
+        const originalWarn = console.warn;
+        console.warn = () => {
+          warnCalled = true;
+        };
+
+        try {
+          securityMonitoring(req, res, () => {
+            nextCalled = true;
+          });
+        } finally {
+          console.warn = originalWarn;
+        }
+
+        expect(nextCalled).toBe(true);
+        expect(warnCalled).toBe(true);
+      },
+    },
+  ],
+});

--- a/test/setup/globals.ts
+++ b/test/setup/globals.ts
@@ -1,0 +1,115 @@
+import { deepEqual, matchObject } from './utils';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var expect: ReturnType<typeof createExpect>;
+}
+
+function createExpect() {
+  const expectFn = (actual: unknown) => {
+    const assertionError = (message: string): never => {
+      throw new Error(message);
+    };
+
+    const api = {
+      toBe(expected: unknown) {
+        if (!Object.is(actual, expected)) {
+          assertionError(`Expected ${JSON.stringify(actual)} to be ${JSON.stringify(expected)}`);
+        }
+      },
+      toEqual(expected: unknown) {
+        if (!deepEqual(actual, expected)) {
+          assertionError(`Expected ${JSON.stringify(actual)} to deeply equal ${JSON.stringify(expected)}`);
+        }
+      },
+      toBeTruthy() {
+        if (!actual) {
+          assertionError(`Expected value to be truthy but received ${JSON.stringify(actual)}`);
+        }
+      },
+      toBeFalsy() {
+        if (actual) {
+          assertionError(`Expected value to be falsy but received ${JSON.stringify(actual)}`);
+        }
+      },
+      toContain(expected: unknown) {
+        if (typeof actual === 'string') {
+          if (!actual.includes(String(expected))) {
+            assertionError(`Expected string to contain ${String(expected)}, got ${actual}`);
+          }
+          return;
+        }
+
+        if (Array.isArray(actual)) {
+          if (!actual.some(item => deepEqual(item, expected))) {
+            assertionError(`Expected array to contain ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+          }
+          return;
+        }
+
+        assertionError('toContain is only supported for strings and arrays');
+      },
+      toHaveLength(expected: number) {
+        if ((actual as any)?.length !== expected) {
+          assertionError(`Expected length ${expected}, got ${(actual as any)?.length}`);
+        }
+      },
+      toMatchObject(expected: Record<string, unknown>) {
+        if (typeof actual !== 'object' || actual === null) {
+          assertionError('toMatchObject requires an object value');
+        }
+
+        if (!matchObject(actual as Record<string, unknown>, expected)) {
+          assertionError(`Expected object to match ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+        }
+      },
+      toBeInstanceOf(expected: new (...args: any[]) => any) {
+        if (!(actual instanceof expected)) {
+          const name = expected?.name ?? 'constructor';
+          assertionError(`Expected value to be instance of ${name}`);
+        }
+      },
+      toBeDefined() {
+        if (typeof actual === 'undefined') {
+          assertionError('Expected value to be defined');
+        }
+      },
+      toThrow(message?: string | RegExp) {
+        if (typeof actual !== 'function') {
+          assertionError('toThrow expects a function');
+        }
+
+        let didThrow = false;
+        try {
+          actual();
+        } catch (error) {
+          didThrow = true;
+          if (message) {
+            const text = error instanceof Error ? error.message : String(error);
+            if (message instanceof RegExp) {
+              if (!message.test(text)) {
+                assertionError(`Expected error message to match ${message}, got ${text}`);
+              }
+            } else if (text !== message) {
+              assertionError(`Expected error message to be ${message}, got ${text}`);
+            }
+          }
+        }
+
+        if (!didThrow) {
+          assertionError('Expected function to throw');
+        }
+      },
+    } as const;
+
+    return api;
+  };
+
+  return expectFn;
+}
+
+export function setupTestGlobals(): void {
+  if (!(globalThis as any).expect) {
+    (globalThis as any).expect = createExpect();
+  }
+}

--- a/test/setup/globals.ts
+++ b/test/setup/globals.ts
@@ -50,8 +50,9 @@ function createExpect() {
         assertionError('toContain is only supported for strings and arrays');
       },
       toHaveLength(expected: number) {
-        if ((actual as any)?.length !== expected) {
-          assertionError(`Expected length ${expected}, got ${(actual as any)?.length}`);
+        const length = (actual as any)?.length;
+        if (length !== expected) {
+          assertionError(`Expected length ${expected}, got ${length}`);
         }
       },
       toMatchObject(expected: Record<string, unknown>) {

--- a/test/setup/test-runner.ts
+++ b/test/setup/test-runner.ts
@@ -1,0 +1,117 @@
+import path from 'node:path';
+
+export interface TestCase {
+  name: string;
+  fn: () => void | Promise<void>;
+}
+
+export interface TestSuite {
+  tests: TestCase[];
+  beforeAll?: () => void | Promise<void>;
+  afterAll?: () => void | Promise<void>;
+}
+
+interface RegisteredSuite extends TestSuite {
+  name: string;
+  file?: string;
+}
+
+interface TestResults {
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+}
+
+class TestRunner {
+  private suites: RegisteredSuite[] = [];
+
+  registerSuite(name: string, suite: TestSuite): void {
+    let file: string | undefined;
+
+    const stack = new Error().stack?.split('\n') ?? [];
+    for (const line of stack) {
+      const match = line.match(/(\/[^:]+\.(?:test|spec)\.[tj]sx?)/i);
+      if (match) {
+        const resolved = match[1];
+        const relative = path.relative(process.cwd(), resolved);
+        file = relative || resolved;
+        break;
+      }
+    }
+
+    this.suites.push({ name, file, ...suite });
+  }
+
+  async run(pattern?: string): Promise<TestResults> {
+    const escapeRegex = (value: string) =>
+      value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+    const matcher = pattern ? new RegExp(escapeRegex(pattern), 'i') : null;
+    let total = 0;
+    let passed = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    for (const suite of this.suites) {
+      const suiteMatches = matcher
+        ? matcher.test(suite.name) || (suite.file ? matcher.test(suite.file) : false)
+        : true;
+
+      if (matcher && !suiteMatches) {
+        const hasMatchingTest = suite.tests.some(test => matcher.test(test.name));
+        if (!hasMatchingTest) {
+          skipped += suite.tests.length;
+          continue;
+        }
+      }
+
+      console.log(`\nSuite: ${suite.name}`);
+
+      if (suite.beforeAll) {
+        await suite.beforeAll();
+      }
+
+      for (const test of suite.tests) {
+        if (
+          matcher &&
+          !matcher.test(test.name) &&
+          !matcher.test(suite.name) &&
+          !(suite.file && matcher.test(suite.file))
+        ) {
+          skipped += 1;
+          continue;
+        }
+
+        total += 1;
+        const start = Date.now();
+
+        try {
+          await test.fn();
+          passed += 1;
+          console.log(`  ✓ ${test.name} (${Date.now() - start}ms)`);
+        } catch (error) {
+          failed += 1;
+          console.error(`  ✗ ${test.name}`);
+          if (error instanceof Error) {
+            console.error(`    ${error.message}`);
+            if (error.stack) {
+              console.error(error.stack.split('\n').slice(1).map(line => `    ${line.trim()}`).join('\n'));
+            }
+          } else {
+            console.error(`    ${String(error)}`);
+          }
+        }
+      }
+
+      if (suite.afterAll) {
+        await suite.afterAll();
+      }
+    }
+
+    console.log(`\nTest Results: ${passed} passed, ${failed} failed, ${skipped} skipped`);
+
+    return { total, passed, failed, skipped };
+  }
+}
+
+export const testRunner = new TestRunner();

--- a/test/setup/test-runner.ts
+++ b/test/setup/test-runner.ts
@@ -31,7 +31,7 @@ class TestRunner {
 
     const stack = new Error().stack?.split('\n') ?? [];
     for (const line of stack) {
-      const match = line.match(/(\/[^:]+\.(?:test|spec)\.[tj]sx?)/i);
+      const match = line.match(/((?:[A-Za-z]:)?[\\/][^:]+?\.(?:test|spec)\.[tj]sx?)/i);
       if (match) {
         const resolved = match[1];
         const relative = path.relative(process.cwd(), resolved);

--- a/test/setup/utils.ts
+++ b/test/setup/utils.ts
@@ -1,0 +1,50 @@
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) {
+    return true;
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) {
+      return false;
+    }
+
+    return a.every((item, index) => deepEqual(item, b[index]));
+  }
+
+  if (isObject(a) && isObject(b)) {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+
+    if (aKeys.length !== bKeys.length) {
+      return false;
+    }
+
+    return aKeys.every(key => deepEqual(a[key], b[key]));
+  }
+
+  return false;
+}
+
+export function matchObject(target: Record<string, unknown>, expected: Record<string, unknown>): boolean {
+  return Object.entries(expected).every(([key, value]) => {
+    if (!(key in target)) {
+      return false;
+    }
+
+    const targetValue = target[key];
+
+    if (isObject(value) && isObject(targetValue)) {
+      return matchObject(targetValue, value as Record<string, unknown>);
+    }
+
+    if (Array.isArray(value) && Array.isArray(targetValue)) {
+      return value.every((item, index) => deepEqual(item, targetValue[index]));
+    }
+
+    return deepEqual(targetValue, value);
+  });
+}


### PR DESCRIPTION
## Summary
- enhance the custom test runner to track originating files and allow path-based filtering
- document suite-specific npm test commands in the main README and AI UX feature guide

## Testing
- npm test
- npm test -- test/ai-ux-features.test.ts
- npm test -- test/security.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f4e31b67ac8320a0b12cab4e76bd70