### PR TITLE
Remove enterprise phone number from contact sales page

### DIFF
--- a/client/src/pages/ContactSales.tsx
+++ b/client/src/pages/ContactSales.tsx
@@ -8,8 +8,8 @@ import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useLocation } from 'wouter';
 import { useAuth } from '@/hooks/use-auth';
-import { 
-  Code, Building2, Users, Mail, Phone, Globe, MessageSquare,
+import {
+  Code, Building2, Users, Mail, Globe, MessageSquare,
   ChevronRight, Check, Calendar, Clock, Shield, Sparkles, ArrowRight
 } from 'lucide-react';
 import { useState } from 'react';
@@ -351,10 +351,6 @@ export default function ContactSales() {
                   <div className="flex items-center gap-3">
                     <Mail className="h-5 w-5 text-muted-foreground" />
                     <span className="text-sm">enterprise@e-code.ai</span>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <Phone className="h-5 w-5 text-muted-foreground" />
-                    <span className="text-sm">1-888-ECODE-01</span>
                   </div>
                   <div className="flex items-center gap-3">
                     <Clock className="h-5 w-5 text-muted-foreground" />


### PR DESCRIPTION
## Summary
- remove the Talk to Sales phone number from the contact sales sidebar
- drop the unused Phone icon import after removing the phone number

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f4e74768a08320bd2e5c93dd1bba64