### PR TITLE
Update email addresses to e-code.ai domain

### DIFF
--- a/attached_assets/Pasted--E-Code-Platform-Pitch-Deck-Slide-1-Cover-E-Code-The-Future-of-Cloud-Development-Buil-1754420112633_1754420112636.txt
+++ b/attached_assets/Pasted--E-Code-Platform-Pitch-Deck-Slide-1-Cover-E-Code-The-Future-of-Cloud-Development-Buil-1754420112633_1754420112636.txt
@@ -301,7 +301,7 @@
 ## Contact Information
 **E-Code Development Team**
 - **Website**: e-code.com
-- **Email**: investors@e-code.com
+- **Email**: investors@e-code.ai
 - **Demo**: demo.e-code.com
 - **GitHub**: github.com/e-code-platform
 

--- a/client/src/pages/CommercialAgreement.tsx
+++ b/client/src/pages/CommercialAgreement.tsx
@@ -202,7 +202,7 @@ export default function CommercialAgreement() {
               <p className="text-sm text-muted-foreground">
                 <strong>Version:</strong> 2.0<br />
                 <strong>Last Updated:</strong> January 1, 2025<br />
-                For questions about this agreement, please contact <a href="mailto:enterprise@e-code.com" className="text-primary hover:underline">enterprise@e-code.com</a>
+                For questions about this agreement, please contact <a href="mailto:enterprise@e-code.ai" className="text-primary hover:underline">enterprise@e-code.ai</a>
               </p>
             </div>
           </div>

--- a/client/src/pages/DPA.tsx
+++ b/client/src/pages/DPA.tsx
@@ -186,7 +186,7 @@ export default function DPA() {
               <p className="text-sm text-muted-foreground">
                 <strong>Last Updated:</strong> January 1, 2025<br />
                 <strong>Effective Date:</strong> Upon execution of the Principal Agreement<br />
-                For questions about this DPA, please contact our Data Protection Officer at <a href="mailto:privacy@e-code.com" className="text-primary hover:underline">privacy@e-code.com</a>
+                For questions about this DPA, please contact our Data Protection Officer at <a href="mailto:privacy@e-code.ai" className="text-primary hover:underline">privacy@e-code.ai</a>
               </p>
             </div>
           </div>

--- a/client/src/pages/Press.tsx
+++ b/client/src/pages/Press.tsx
@@ -223,7 +223,7 @@ export default function Press() {
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Button size="lg" asChild>
-                <a href="mailto:press@e-code.com">
+                <a href="mailto:press@e-code.ai">
                   <Mail className="mr-2 h-5 w-5" />
                   Contact Press Team
                 </a>
@@ -488,8 +488,8 @@ export default function Press() {
           <div className="text-center mt-8">
             <p className="text-sm text-muted-foreground">
               For custom assets or additional resources, please contact{' '}
-              <a href="mailto:press@e-code.com" className="text-primary hover:underline">
-                press@e-code.com
+              <a href="mailto:press@e-code.ai" className="text-primary hover:underline">
+                press@e-code.ai
               </a>
             </p>
           </div>
@@ -510,8 +510,8 @@ export default function Press() {
               <div className="space-y-4">
                 <div>
                   <p className="font-semibold">Email</p>
-                  <a href="mailto:press@e-code.com" className="text-primary hover:underline">
-                    press@e-code.com
+                  <a href="mailto:press@e-code.ai" className="text-primary hover:underline">
+                    press@e-code.ai
                   </a>
                 </div>
                 <div>
@@ -522,7 +522,7 @@ export default function Press() {
                 </div>
               </div>
               <Button className="mt-8" asChild>
-                <a href="mailto:press@e-code.com">
+                <a href="mailto:press@e-code.ai">
                   <Mail className="mr-2 h-5 w-5" />
                   Contact Press Team
                 </a>

--- a/client/src/pages/Privacy.tsx
+++ b/client/src/pages/Privacy.tsx
@@ -87,7 +87,7 @@ export default function Privacy() {
                 </p>
                 <div className="mt-4 p-4 bg-muted rounded-lg">
                   <p>E-Code Inc.</p>
-                  <p>Email: privacy@e-code.com</p>
+                  <p>Email: privacy@e-code.ai</p>
                   <p>Address: 548 Market St #16093, San Francisco, CA 94104</p>
                 </div>
               </section>

--- a/client/src/pages/ReportAbuse.tsx
+++ b/client/src/pages/ReportAbuse.tsx
@@ -299,7 +299,7 @@ export default function ReportAbuse() {
                   </p>
                   <Button variant="outline" size="sm" className="w-full">
                     <ExternalLink className="h-4 w-4 mr-2" />
-                    abuse@e-code.com
+                    abuse@e-code.ai
                   </Button>
                 </CardContent>
               </Card>

--- a/client/src/pages/StudentDPA.tsx
+++ b/client/src/pages/StudentDPA.tsx
@@ -129,7 +129,7 @@ export default function StudentDPA() {
                 </a>
               </Button>
               <Button size="lg" variant="outline" asChild>
-                <a href="mailto:education@e-code.com">
+                <a href="mailto:education@e-code.ai">
                   <Mail className="mr-2 h-5 w-5" />
                   Contact Education Team
                 </a>
@@ -534,8 +534,8 @@ export default function StudentDPA() {
                   For DPA questions and execution
                 </p>
                 <Button variant="outline" asChild className="w-full">
-                  <a href="mailto:education@e-code.com">
-                    education@e-code.com
+                  <a href="mailto:education@e-code.ai">
+                    education@e-code.ai
                   </a>
                 </Button>
               </CardContent>

--- a/client/src/pages/Subprocessors.tsx
+++ b/client/src/pages/Subprocessors.tsx
@@ -385,7 +385,7 @@ export default function Subprocessors() {
                       Stay informed about changes to our subprocessor list
                     </p>
                     <Button className="w-full" asChild>
-                      <a href="mailto:privacy@e-code.com?subject=Subscribe to Subprocessor Updates">
+                      <a href="mailto:privacy@e-code.ai?subject=Subscribe to Subprocessor Updates">
                         Subscribe to Notifications
                       </a>
                     </Button>
@@ -468,7 +468,7 @@ export default function Subprocessors() {
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <Button asChild>
-                  <a href="mailto:privacy@e-code.com">
+                  <a href="mailto:privacy@e-code.ai">
                     <Mail className="mr-2 h-4 w-4" />
                     Contact Privacy Team
                   </a>

--- a/client/src/pages/Terms.tsx
+++ b/client/src/pages/Terms.tsx
@@ -99,7 +99,7 @@ export default function Terms() {
                 </p>
                 <div className="mt-4 p-4 bg-muted rounded-lg">
                   <p>E-Code Inc.</p>
-                  <p>Email: legal@e-code.com</p>
+                  <p>Email: legal@e-code.ai</p>
                   <p>Address: 548 Market St #16093, San Francisco, CA 94104</p>
                 </div>
               </section>

--- a/server/git.ts
+++ b/server/git.ts
@@ -147,7 +147,7 @@ export async function initRepo(projectId: number): Promise<GitResult> {
       'commit', 
       '-m', 
       'Initial commit',
-      '--author="E-CODE <system@e-code.com>"'
+      '--author="E-CODE <system@e-code.ai>"'
     ]);
     
     return { 

--- a/server/seed-blog.ts
+++ b/server/seed-blog.ts
@@ -394,7 +394,7 @@ Over 10,000 schools and 5 million students worldwide use E-Code for computer sci
 3. Create your first class
 4. Watch your students thrive
 
-*Questions about E-Code for Education? Contact our education team at education@e-code.com or join our next educator webinar.*`,
+*Questions about E-Code for Education? Contact our education team at education@e-code.ai or join our next educator webinar.*`,
         excerpt: "Discover how E-Code is revolutionizing computer science education with instant development environments, real-time collaboration, and powerful classroom management tools.",
         author: "Dr. Emily Watson",
         authorRole: "Head of Education",
@@ -742,7 +742,7 @@ Ready to transform how your team builds software? Create your team account today
 
 [Create Your Team →]
 
-*Questions? Contact our sales team at teams@e-code.com or schedule a demo to see E-Code Teams in action.*`,
+*Questions? Contact our sales team at teams@e-code.ai or schedule a demo to see E-Code Teams in action.*`,
         excerpt: "Transform how your development team collaborates with shared workspaces, real-time editing, advanced permissions, and powerful analytics.",
         author: "Lisa Martinez",
         authorRole: "VP of Product",

--- a/server/sso/enterprise-sso-service.ts
+++ b/server/sso/enterprise-sso-service.ts
@@ -161,7 +161,7 @@ export class EnterpriseSSOService {
             contactPerson: [{
               contactType: 'technical',
               givenName: 'E-Code Support',
-              emailAddress: 'support@e-code.com'
+              emailAddress: 'support@e-code.ai'
             }],
             assertionConsumerService: [{
               Binding: saml.Constants.namespace.binding.post,

--- a/server/utils/email-utils.ts
+++ b/server/utils/email-utils.ts
@@ -8,7 +8,7 @@ const emailConfig = {
   port: parseInt(process.env.SMTP_PORT || '587'),
   secure: process.env.SMTP_SECURE === 'true',
   auth: {
-    user: process.env.SMTP_USER || 'noreply@e-code.com',
+    user: process.env.SMTP_USER || 'noreply@e-code.ai',
     pass: process.env.SMTP_PASS || ''
   }
 };


### PR DESCRIPTION
## Summary
- replace all `@e-code.com` email addresses with `@e-code.ai` across client pages, server utilities, and documentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f4eae5bf648320bf16257db29a6269