### PR TITLE
Track form submissions and expose admin request dashboard

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -46,6 +46,7 @@ const AdminDashboard = lazy(() => import("@/pages/AdminDashboard"));
 const AdminUsage = lazy(() => import("@/pages/AdminUsage"));
 const AdminBilling = lazy(() => import("@/pages/AdminBilling"));
 const AdminAIModels = lazy(() => import("@/pages/admin/AIModels"));
+const AdminFormRequests = lazy(() => import("@/pages/admin/FormRequests"));
 const PitchDeck = lazy(() => import("@/pages/admin/PitchDeck"));
 // Public pages
 const Landing = lazy(() => import("@/pages/Landing"));
@@ -692,6 +693,11 @@ function AppContent() {
           <ProtectedRoute path="/admin/usage" component={() => (
             <ReplitLayout>
               <AdminUsage />
+            </ReplitLayout>
+          )} />
+          <ProtectedRoute path="/admin/requests" component={() => (
+            <ReplitLayout>
+              <AdminFormRequests />
             </ReplitLayout>
           )} />
           <ProtectedRoute path="/admin/billing" component={() => (

--- a/client/src/pages/ContactSales.tsx
+++ b/client/src/pages/ContactSales.tsx
@@ -37,8 +37,13 @@ export default function ContactSales() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsSubmitting(true);
-    
+
     try {
+      const pagePath = typeof window !== 'undefined' ? window.location.pathname : '/contact-sales';
+      const subject = formData.interest
+        ? `Enterprise inquiry - ${formData.interest}`
+        : 'Enterprise inquiry';
+
       const response = await fetch('/api/contact/sales', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -50,7 +55,9 @@ export default function ContactSales() {
           phone: formData.phone,
           message: formData.message,
           companySize: formData.companySize,
-          useCase: formData.interest
+          useCase: formData.interest,
+          subject,
+          pagePath,
         }),
       });
 

--- a/client/src/pages/ReportAbuse.tsx
+++ b/client/src/pages/ReportAbuse.tsx
@@ -24,7 +24,8 @@ export default function ReportAbuse() {
     try {
       const formElement = e.target as HTMLFormElement;
       const formData = new FormData(formElement);
-      
+      const pagePath = typeof window !== 'undefined' ? window.location.pathname : '/report-abuse';
+
       const response = await fetch('/api/report/abuse', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -33,7 +34,9 @@ export default function ReportAbuse() {
           reportType: reportType,
           targetUrl: formData.get('url'),
           description: formData.get('description'),
-          reporterEmail: formData.get('email')
+          reporterEmail: formData.get('email'),
+          username: formData.get('username'),
+          pagePath,
         }),
       });
 

--- a/client/src/pages/Support.tsx
+++ b/client/src/pages/Support.tsx
@@ -22,6 +22,9 @@ export default function Support() {
   const [ticketType, setTicketType] = useState('');
   const [ticketSubject, setTicketSubject] = useState('');
   const [ticketDescription, setTicketDescription] = useState('');
+  const [ticketName, setTicketName] = useState('');
+  const [ticketEmail, setTicketEmail] = useState('');
+  const [isSubmittingTicket, setIsSubmittingTicket] = useState(false);
 
   const faqs = [
     {
@@ -110,16 +113,54 @@ export default function Support() {
     }
   ];
 
-  const handleSubmitTicket = (e: React.FormEvent) => {
+  const handleSubmitTicket = async (e: React.FormEvent) => {
     e.preventDefault();
-    toast({
-      title: "Support ticket created",
-      description: "We'll get back to you within 24-48 hours."
-    });
-    // Reset form
-    setTicketType('');
-    setTicketSubject('');
-    setTicketDescription('');
+    setIsSubmittingTicket(true);
+
+    try {
+      const pagePath = typeof window !== 'undefined' ? window.location.pathname : '/support';
+      const response = await fetch('/api/support/tickets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          name: ticketName,
+          email: ticketEmail,
+          issueType: ticketType,
+          subject: ticketSubject,
+          description: ticketDescription,
+          pagePath,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        toast({
+          title: 'Support ticket created',
+          description: data.message || "We'll get back to you within 24-48 hours.",
+        });
+        setTicketType('');
+        setTicketSubject('');
+        setTicketDescription('');
+        setTicketName('');
+        setTicketEmail('');
+      } else {
+        toast({
+          title: 'Unable to submit support ticket',
+          description: data.error || 'Please try again in a few moments.',
+          variant: 'destructive',
+        });
+      }
+    } catch (error) {
+      toast({
+        title: 'Network error',
+        description: 'Failed to submit support ticket. Please check your connection and try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSubmittingTicket(false);
+    }
   };
 
   const toggleFaq = (id: number) => {
@@ -316,6 +357,30 @@ export default function Support() {
                   </select>
                 </div>
 
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="ticket-name">Your Name</Label>
+                    <Input
+                      id="ticket-name"
+                      value={ticketName}
+                      onChange={(e) => setTicketName(e.target.value)}
+                      placeholder="How should we address you?"
+                      required
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="ticket-email">Work Email</Label>
+                    <Input
+                      id="ticket-email"
+                      type="email"
+                      value={ticketEmail}
+                      onChange={(e) => setTicketEmail(e.target.value)}
+                      placeholder="you@example.com"
+                      required
+                    />
+                  </div>
+                </div>
+
                 <div className="space-y-2">
                   <Label htmlFor="subject">Subject</Label>
                   <Input
@@ -348,8 +413,8 @@ export default function Support() {
                   </ul>
                 </div>
 
-                <Button type="submit" className="w-full">
-                  Submit Support Ticket
+                <Button type="submit" className="w-full" disabled={isSubmittingTicket}>
+                  {isSubmittingTicket ? 'Submitting...' : 'Submit Support Ticket'}
                 </Button>
               </form>
             </CardContent>

--- a/client/src/pages/admin/AdminLayout.tsx
+++ b/client/src/pages/admin/AdminLayout.tsx
@@ -2,15 +2,16 @@
 import { ReactNode } from 'react';
 import { Link, useLocation } from 'wouter';
 import { 
-  LayoutDashboard, 
-  Users, 
-  Key, 
-  FileText, 
-  Ticket, 
+  LayoutDashboard,
+  Users,
+  Key,
+  FileText,
+  Ticket,
   CreditCard,
   Book,
   Activity,
   Settings,
+  Inbox,
   LogOut
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -24,6 +25,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
 
   const navItems = [
     { path: '/admin', icon: LayoutDashboard, label: 'Dashboard' },
+    { path: '/admin/requests', icon: Inbox, label: 'Customer Requests' },
     { path: '/admin/users', icon: Users, label: 'Users' },
     { path: '/admin/api-keys', icon: Key, label: 'API Keys' },
     { path: '/admin/cms', icon: FileText, label: 'CMS Pages' },

--- a/client/src/pages/admin/FormRequests.tsx
+++ b/client/src/pages/admin/FormRequests.tsx
@@ -1,0 +1,291 @@
+// @ts-nocheck
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { formatDistanceToNow } from 'date-fns';
+import { AdminLayout } from './AdminLayout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Badge } from '@/components/ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { useToast } from '@/hooks/use-toast';
+import { apiRequest } from '@/lib/queryClient';
+import { Mail, Phone, ExternalLink, RefreshCw, Loader2, CheckCircle2, Clock, Archive } from 'lucide-react';
+import { useAuth } from '@/hooks/use-auth';
+
+const FORM_TABS = [
+  { value: 'all', label: 'All Requests' },
+  { value: 'contact_sales', label: 'Sales Inquiries' },
+  { value: 'support_ticket', label: 'Support Tickets' },
+  { value: 'report_abuse', label: 'Abuse Reports' },
+];
+
+const STATUS_OPTIONS = [
+  { value: 'all', label: 'All statuses' },
+  { value: 'new', label: 'New' },
+  { value: 'in_progress', label: 'In progress' },
+  { value: 'resolved', label: 'Resolved' },
+  { value: 'archived', label: 'Archived' },
+];
+
+const STATUS_STYLES: Record<string, string> = {
+  new: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  in_progress: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+  resolved: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+  archived: 'bg-slate-500/10 text-slate-400 border-slate-500/20',
+};
+
+const STATUS_ACTIONS = [
+  { value: 'in_progress', label: 'Mark in progress', icon: Clock },
+  { value: 'resolved', label: 'Mark resolved', icon: CheckCircle2 },
+  { value: 'archived', label: 'Archive', icon: Archive },
+];
+
+export default function AdminFormRequests() {
+  const [activeTab, setActiveTab] = useState('all');
+  const [statusFilter, setStatusFilter] = useState('all');
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+
+  if (!user || !user.email?.includes('admin')) {
+    return (
+      <div className="container mx-auto py-16">
+        <Card>
+          <CardContent className="py-12">
+            <p className="text-center text-muted-foreground">
+              Access denied. Admin privileges required.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const { data, isLoading, isFetching, refetch } = useQuery({
+    queryKey: [`/api/admin/form-requests?formType=${activeTab}&status=${statusFilter}`],
+  });
+
+  const requests = data?.requests || [];
+
+  const updateStatus = useMutation({
+    mutationFn: async ({ id, status }: { id: number; status: string }) => {
+      const res = await apiRequest('PATCH', `/api/admin/form-requests/${id}`, { status });
+      if (!res.ok) {
+        const errorText = await res.text();
+        throw new Error(errorText || 'Unable to update request status');
+      }
+      return await res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [`/api/admin/form-requests?formType=${activeTab}&status=${statusFilter}`] });
+      toast({
+        title: 'Request updated',
+        description: 'The request status has been updated successfully.',
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: 'Update failed',
+        description: error.message || 'Unable to update request status.',
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const groupedRequests = requests;
+
+  return (
+    <AdminLayout>
+      <div className="p-8 space-y-8">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-white">Customer Requests</h1>
+            <p className="text-sm text-zinc-400">
+              Track every form submission from marketing pages, trust & safety, and support.
+            </p>
+          </div>
+          <Button variant="outline" onClick={() => refetch()} disabled={isFetching} className="text-white border-zinc-700">
+            {isFetching ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Refreshing
+              </>
+            ) : (
+              <>
+                <RefreshCw className="mr-2 h-4 w-4" />
+                Refresh
+              </>
+            )}
+          </Button>
+        </div>
+
+        <Card className="bg-zinc-900 border-zinc-800">
+          <CardHeader className="pb-4">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <CardTitle className="text-white">Request Filters</CardTitle>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full sm:w-auto">
+                  <TabsList className="bg-zinc-800/60 border border-zinc-700">
+                    {FORM_TABS.map((tab) => (
+                      <TabsTrigger
+                        key={tab.value}
+                        value={tab.value}
+                        className="data-[state=active]:bg-zinc-700 data-[state=active]:text-white"
+                      >
+                        {tab.label}
+                      </TabsTrigger>
+                    ))}
+                  </TabsList>
+                </Tabs>
+
+                <Select value={statusFilter} onValueChange={setStatusFilter}>
+                  <SelectTrigger className="w-full sm:w-48 bg-zinc-800 border-zinc-700 text-white">
+                    <SelectValue placeholder="Status" />
+                  </SelectTrigger>
+                  <SelectContent className="bg-zinc-900 border-zinc-700 text-white">
+                    {STATUS_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="p-0">
+            {isLoading ? (
+              <div className="py-12 flex flex-col items-center justify-center text-zinc-400">
+                <Loader2 className="h-8 w-8 animate-spin mb-3" />
+                Loading requests...
+              </div>
+            ) : groupedRequests.length === 0 ? (
+              <div className="py-16 flex flex-col items-center justify-center text-zinc-500">
+                <CheckCircle2 className="h-10 w-10 mb-3" />
+                <p className="font-medium">No requests to show</p>
+                <p className="text-sm text-zinc-500 mt-1 text-center max-w-md">
+                  Once customers reach out through sales, support, or trust & safety forms, their submissions will appear here.
+                </p>
+              </div>
+            ) : (
+              <ScrollArea className="max-h-[70vh]">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="border-zinc-800">
+                      <TableHead className="text-zinc-400">Received</TableHead>
+                      <TableHead className="text-zinc-400">Source</TableHead>
+                      <TableHead className="text-zinc-400">Sender</TableHead>
+                      <TableHead className="text-zinc-400">Request</TableHead>
+                      <TableHead className="text-zinc-400">Status</TableHead>
+                      <TableHead className="text-right text-zinc-400">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {groupedRequests.map((request: any) => {
+                      const statusClass = STATUS_STYLES[request.status] || STATUS_STYLES.new;
+                      const createdAt = request.createdAt ? new Date(request.createdAt) : null;
+                      return (
+                        <TableRow key={request.id} className="border-zinc-900 hover:bg-zinc-800/50">
+                          <TableCell className="text-sm text-zinc-300">
+                            {createdAt ? formatDistanceToNow(createdAt, { addSuffix: true }) : '—'}
+                          </TableCell>
+                          <TableCell className="text-sm text-zinc-300">
+                            <div className="flex flex-col">
+                              <span className="font-medium capitalize">
+                                {request.formType?.replace('_', ' ') || 'Request'}
+                              </span>
+                              <span className="text-xs text-zinc-500">{request.pagePath || '—'}</span>
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-sm text-zinc-300">
+                            <div className="space-y-1">
+                              <p className="font-medium text-white">{request.name || request.senderName || 'Unknown contact'}</p>
+                              {request.senderCompany ? (
+                                <p className="text-xs text-zinc-500">{request.senderCompany}</p>
+                              ) : null}
+                              {request.email || request.senderEmail ? (
+                                <p className="flex items-center gap-2 text-xs text-blue-400">
+                                  <Mail className="h-3 w-3" />
+                                  {request.email || request.senderEmail}
+                                </p>
+                              ) : null}
+                              {request.phone || request.senderPhone ? (
+                                <p className="flex items-center gap-2 text-xs text-zinc-500">
+                                  <Phone className="h-3 w-3" />
+                                  {request.phone || request.senderPhone}
+                                </p>
+                              ) : null}
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-sm text-zinc-300">
+                            <div className="space-y-1">
+                              {request.subject ? (
+                                <p className="font-medium text-white">{request.subject}</p>
+                              ) : null}
+                              {request.metadata?.issueType ? (
+                                <Badge variant="outline" className="border-zinc-700 text-zinc-300 bg-transparent">
+                                  {request.metadata.issueType.replace('_', ' ')}
+                                </Badge>
+                              ) : null}
+                              <p className="text-xs text-zinc-400 whitespace-pre-wrap">
+                                {request.message?.slice(0, 200) || '—'}
+                                {request.message && request.message.length > 200 ? '…' : ''}
+                              </p>
+                              {request.metadata?.targetUrl ? (
+                                <a
+                                  href={request.metadata.targetUrl}
+                                  className="inline-flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300"
+                                  target="_blank"
+                                  rel="noreferrer"
+                                >
+                                  <ExternalLink className="h-3 w-3" />
+                                  {request.metadata.targetUrl}
+                                </a>
+                              ) : null}
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <Badge className={`${statusClass} border`}>{request.status?.replace('_', ' ')}</Badge>
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <div className="inline-flex gap-2">
+                              {STATUS_ACTIONS.map((action) => {
+                                const Icon = action.icon;
+                                const disabled = updateStatus.isLoading || request.status === action.value;
+                                return (
+                                  <Button
+                                    key={action.value}
+                                    size="sm"
+                                    variant="outline"
+                                    disabled={disabled}
+                                    className="border-zinc-700 text-zinc-200 hover:bg-zinc-800"
+                                    onClick={() => updateStatus.mutate({ id: request.id, status: action.value })}
+                                  >
+                                    {updateStatus.isLoading && updateStatus.variables?.id === request.id &&
+                                    updateStatus.variables?.status === action.value ? (
+                                      <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+                                    ) : (
+                                      <Icon className="mr-2 h-3 w-3" />
+                                    )}
+                                    <span className="text-xs">{action.label}</span>
+                                  </Button>
+                                );
+                              })}
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </ScrollArea>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </AdminLayout>
+  );
+}

--- a/server/db/migrations/20251020_add_customer_requests_table.sql
+++ b/server/db/migrations/20251020_add_customer_requests_table.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS customer_requests (
+    id SERIAL PRIMARY KEY,
+    form_type VARCHAR(64) NOT NULL,
+    page_path VARCHAR(255) NOT NULL,
+    sender_name VARCHAR(255),
+    sender_email VARCHAR(320),
+    sender_company VARCHAR(255),
+    sender_phone VARCHAR(50),
+    subject VARCHAR(255),
+    message TEXT,
+    status VARCHAR(32) NOT NULL DEFAULT 'new',
+    metadata JSONB DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    resolved_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_customer_requests_form_type ON customer_requests(form_type);
+CREATE INDEX IF NOT EXISTS idx_customer_requests_status ON customer_requests(status);
+CREATE INDEX IF NOT EXISTS idx_customer_requests_created_at ON customer_requests(created_at DESC);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -21727,7 +21727,7 @@ Generate a comprehensive application based on the user's request. Include all ne
   // Contact Sales endpoint
   app.post('/api/contact/sales', async (req, res) => {
     try {
-      const { name, email, company, phone, message, companySize, useCase } = req.body;
+      const { name, email, company, phone, message, companySize, useCase, pagePath } = req.body;
       
       // Validate required fields
       if (!name || !email || !message) {
@@ -21744,7 +21744,7 @@ Generate a comprehensive application based on the user's request. Include all ne
         companySize: companySize || 'unknown',
         useCase: useCase || 'general',
         status: 'new',
-        createdAt: new Date()
+        pagePath: pagePath || '/contact-sales'
       });
       
       // Log the inquiry for sales team
@@ -21753,24 +21753,123 @@ Generate a comprehensive application based on the user's request. Include all ne
         name,
         email,
         company,
-        companySize
+        companySize,
+        pagePath: inquiry.pagePath
       });
-      
-      res.json({ 
-        success: true, 
+
+      res.json({
+        success: true,
         message: 'Thank you for your interest! Our sales team will contact you within 24 hours.',
-        inquiryId: inquiry.id
+        inquiryId: inquiry.id,
+        pagePath: inquiry.pagePath
       });
     } catch (error) {
       logger.error('Contact sales error:', error);
       res.status(500).json({ error: 'Failed to submit sales inquiry. Please try again.' });
     }
   });
-  
+
+  // Support ticket endpoint
+  app.post('/api/support/tickets', async (req, res) => {
+    try {
+      const { name, email, issueType, subject, description, pagePath } = req.body;
+
+      if (!email || !issueType || !subject || !description) {
+        return res.status(400).json({ error: 'Email, issue type, subject, and description are required' });
+      }
+
+      const request = await storage.createCustomerRequest({
+        formType: 'support_ticket',
+        pagePath: pagePath || '/support',
+        senderName: name || null,
+        senderEmail: email,
+        subject: `[${issueType}] ${subject}`,
+        message: description,
+        metadata: {
+          issueType,
+        },
+      });
+
+      logger.info('Support ticket submitted', {
+        id: request.id,
+        email,
+        issueType,
+        pagePath: request.pagePath,
+      });
+
+      res.json({
+        success: true,
+        message: 'Support ticket submitted successfully. Our team will follow up shortly.',
+        ticketId: request.id,
+        pagePath: request.pagePath,
+      });
+    } catch (error) {
+      logger.error('Support ticket submission error:', error);
+      res.status(500).json({ error: 'Failed to submit support ticket. Please try again.' });
+    }
+  });
+
+  // Admin - view customer form requests
+  app.get('/api/admin/form-requests', ensureAuthenticated, async (req, res) => {
+    const isAdminUser = req.user?.role === 'admin' || req.user?.email?.includes('admin');
+    if (!isAdminUser) {
+      return res.status(403).json({ error: 'Admin access required' });
+    }
+
+    try {
+      const formTypeParam = typeof req.query.formType === 'string' ? req.query.formType : undefined;
+      const statusParam = typeof req.query.status === 'string' ? req.query.status : undefined;
+
+      const requests = await storage.getCustomerRequests({
+        formType: formTypeParam && formTypeParam !== 'all' ? formTypeParam : undefined,
+        status: statusParam && statusParam !== 'all' ? statusParam : undefined,
+      });
+
+      res.json({ requests });
+    } catch (error) {
+      logger.error('Failed to fetch customer requests:', error);
+      res.status(500).json({ error: 'Failed to fetch customer requests' });
+    }
+  });
+
+  app.patch('/api/admin/form-requests/:id', ensureAuthenticated, async (req, res) => {
+    const isAdminUser = req.user?.role === 'admin' || req.user?.email?.includes('admin');
+    if (!isAdminUser) {
+      return res.status(403).json({ error: 'Admin access required' });
+    }
+
+    try {
+      const id = Number(req.params.id);
+      if (Number.isNaN(id)) {
+        return res.status(400).json({ error: 'Invalid request id' });
+      }
+
+      const updatePayload: any = {
+        status: req.body.status,
+        resolvedAt: req.body.status === 'resolved' ? new Date() : undefined,
+      };
+
+      if (req.body.metadata) {
+        updatePayload.metadata = req.body.metadata;
+      }
+
+      const updated = await storage.updateCustomerRequest(id, updatePayload);
+
+      if (!updated) {
+        return res.status(404).json({ error: 'Request not found' });
+      }
+
+      res.json({ request: updated });
+    } catch (error) {
+      logger.error('Failed to update customer request:', error);
+      res.status(500).json({ error: 'Failed to update customer request' });
+    }
+  });
+
   // Report Abuse endpoint
   app.post('/api/report/abuse', async (req, res) => {
     try {
-      const { reportType, targetUrl, description, reporterEmail } = req.body;
+      const { reportType, targetUrl, description, reporterEmail, username, pagePath } = req.body;
       const userId = req.user?.id || null;
       
       // Validate required fields
@@ -21783,10 +21882,14 @@ Generate a comprehensive application based on the user's request. Include all ne
         reportType,
         targetUrl,
         description,
-        reporterEmail: reporterEmail || '',
-        reporterId: userId,
-        status: 'pending',
-        createdAt: new Date()
+        reporterEmail,
+        username,
+        status: 'new',
+        userId,
+        pagePath: pagePath || '/report-abuse',
+        metadata: {
+          reporterUserId: userId,
+        }
       });
       
       // Log the report for moderation team
@@ -21794,13 +21897,15 @@ Generate a comprehensive application based on the user's request. Include all ne
         id: report.id,
         type: reportType,
         target: targetUrl,
-        reporter: userId || 'anonymous'
+        reporter: userId || 'anonymous',
+        pagePath: report.pagePath
       });
-      
-      res.json({ 
-        success: true, 
+
+      res.json({
+        success: true,
         message: 'Thank you for helping keep E-Code safe. We\'ll review your report and take appropriate action.',
-        reportId: report.id
+        reportId: report.id,
+        pagePath: report.pagePath
       });
     } catch (error) {
       logger.error('Report abuse error:', error);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -54,7 +54,8 @@ import {
   insertDynamicIntelligenceSchema, insertWebSearchHistorySchema,
   insertGitRepositorySchema, insertGitCommitSchema, insertCustomDomainSchema,
   insertSecretSchema, insertEnvironmentVariableSchema,
-  insertNewsletterSubscriberSchema, insertNewsletterCampaignSchema, insertNewsletterDeliverySchema
+  insertNewsletterSubscriberSchema, insertNewsletterCampaignSchema, insertNewsletterDeliverySchema,
+  customerRequests, insertCustomerRequestSchema
 } from "@shared/schema";
 import { z } from "zod";
 
@@ -91,6 +92,8 @@ type GitCommit = typeof gitCommits.$inferSelect;
 type InsertGitCommit = z.infer<typeof insertGitCommitSchema>;
 type CustomDomain = typeof customDomains.$inferSelect;
 type InsertCustomDomain = z.infer<typeof insertCustomDomainSchema>;
+type CustomerRequest = typeof customerRequests.$inferSelect;
+type InsertCustomerRequest = z.infer<typeof insertCustomerRequestSchema>;
 
 import { eq, and, desc, isNull, sql, inArray, gte, lte, SQL } from "drizzle-orm";
 import { db } from "./db";
@@ -2617,42 +2620,237 @@ export class DatabaseStorage implements IStorage {
   }
 
   // Sales and Support operations
+  async createCustomerRequest(request: InsertCustomerRequest): Promise<CustomerRequest> {
+    const payload = {
+      ...request,
+      metadata: request.metadata ?? {},
+      status: request.status ?? 'new',
+      createdAt: request.createdAt ?? new Date(),
+      updatedAt: request.updatedAt ?? new Date(),
+    };
+
+    const [created] = await this.db
+      .insert(customerRequests)
+      .values(payload)
+      .returning();
+
+    return created;
+  }
+
+  async getCustomerRequests(filters?: { formType?: string; status?: string; limit?: number }): Promise<CustomerRequest[]> {
+    const conditions: SQL<unknown>[] = [];
+
+    if (filters?.formType) {
+      conditions.push(eq(customerRequests.formType, filters.formType));
+    }
+
+    if (filters?.status) {
+      conditions.push(eq(customerRequests.status, filters.status));
+    }
+
+    let query = this.db
+      .select()
+      .from(customerRequests)
+      .orderBy(desc(customerRequests.createdAt));
+
+    if (conditions.length > 0) {
+      query = query.where(and(...conditions));
+    }
+
+    if (filters?.limit) {
+      query = query.limit(filters.limit);
+    }
+
+    return await query;
+  }
+
+  async updateCustomerRequest(id: number, updates: Partial<CustomerRequest>): Promise<CustomerRequest | undefined> {
+    const payload: Partial<CustomerRequest> = {
+      ...updates,
+      updatedAt: new Date(),
+    };
+
+    if (payload.resolvedAt === undefined) {
+      delete payload.resolvedAt;
+    }
+
+    if (payload.metadata === undefined) {
+      delete payload.metadata;
+    }
+
+    const [updated] = await this.db
+      .update(customerRequests)
+      .set(payload)
+      .where(eq(customerRequests.id, id))
+      .returning();
+
+    return updated;
+  }
+
   async createSalesInquiry(inquiry: any): Promise<any> {
+    const request = await this.createCustomerRequest({
+      formType: 'contact_sales',
+      pagePath: inquiry.pagePath || '/contact-sales',
+      senderName: inquiry.name,
+      senderEmail: inquiry.email,
+      senderCompany: inquiry.company,
+      senderPhone: inquiry.phone,
+      subject: inquiry.subject || (inquiry.useCase ? `Sales inquiry - ${inquiry.useCase}` : 'Sales inquiry'),
+      message: inquiry.message,
+      status: inquiry.status ?? 'new',
+      metadata: {
+        companySize: inquiry.companySize || 'unknown',
+        useCase: inquiry.useCase || 'general',
+        ...(inquiry.metadata || {}),
+      },
+    });
+
     return {
-      id: Date.now(),
       ...inquiry,
-      createdAt: new Date(),
-      updatedAt: new Date()
+      id: request.id,
+      status: request.status,
+      createdAt: request.createdAt,
+      updatedAt: request.updatedAt,
+      pagePath: request.pagePath,
     };
   }
 
   async getSalesInquiries(status?: string): Promise<any[]> {
-    // Would query from sales_inquiries table
-    return [];
+    const inquiries = await this.getCustomerRequests({
+      formType: 'contact_sales',
+      status: status || undefined,
+    });
+
+    return inquiries.map((request) => ({
+      id: request.id,
+      name: request.senderName,
+      email: request.senderEmail,
+      company: request.senderCompany,
+      phone: request.senderPhone,
+      message: request.message,
+      subject: request.subject,
+      companySize: request.metadata?.companySize || 'unknown',
+      useCase: request.metadata?.useCase || 'general',
+      status: request.status,
+      createdAt: request.createdAt,
+      updatedAt: request.updatedAt,
+      pagePath: request.pagePath,
+    }));
   }
 
   async updateSalesInquiry(id: number, updates: any): Promise<any | undefined> {
-    // Would update sales_inquiries table
-    return { id, ...updates };
+    const updated = await this.updateCustomerRequest(id, {
+      senderName: updates.name,
+      senderEmail: updates.email,
+      senderCompany: updates.company,
+      senderPhone: updates.phone,
+      message: updates.message,
+      subject: updates.subject,
+      status: updates.status,
+      metadata: {
+        companySize: updates.companySize,
+        useCase: updates.useCase,
+        ...(updates.metadata || {}),
+      },
+    });
+
+    if (!updated) {
+      return undefined;
+    }
+
+    return {
+      id: updated.id,
+      name: updated.senderName,
+      email: updated.senderEmail,
+      company: updated.senderCompany,
+      phone: updated.senderPhone,
+      message: updated.message,
+      subject: updated.subject,
+      companySize: updated.metadata?.companySize || 'unknown',
+      useCase: updated.metadata?.useCase || 'general',
+      status: updated.status,
+      createdAt: updated.createdAt,
+      updatedAt: updated.updatedAt,
+      pagePath: updated.pagePath,
+    };
   }
 
   async createAbuseReport(report: any): Promise<any> {
+    const request = await this.createCustomerRequest({
+      formType: 'report_abuse',
+      pagePath: report.pagePath || '/report-abuse',
+      senderName: report.reporterName,
+      senderEmail: report.reporterEmail,
+      subject: `Abuse report - ${report.reportType}`,
+      message: report.description,
+      metadata: {
+        reportType: report.reportType,
+        targetUrl: report.targetUrl,
+        username: report.username,
+        reporterUserId: report.userId,
+        ...(report.metadata || {}),
+      },
+    });
+
     return {
-      id: Date.now(),
       ...report,
-      createdAt: new Date(),
-      updatedAt: new Date()
+      id: request.id,
+      status: request.status,
+      createdAt: request.createdAt,
+      updatedAt: request.updatedAt,
+      pagePath: request.pagePath,
     };
   }
 
   async getAbuseReports(status?: string): Promise<any[]> {
-    // Would query from abuse_reports table
-    return [];
+    const reports = await this.getCustomerRequests({
+      formType: 'report_abuse',
+      status: status || undefined,
+    });
+
+    return reports.map((request) => ({
+      id: request.id,
+      reportType: request.metadata?.reportType,
+      targetUrl: request.metadata?.targetUrl,
+      description: request.message,
+      reporterEmail: request.senderEmail,
+      username: request.metadata?.username,
+      status: request.status,
+      createdAt: request.createdAt,
+      updatedAt: request.updatedAt,
+      pagePath: request.pagePath,
+    }));
   }
 
   async updateAbuseReport(id: number, updates: any): Promise<any | undefined> {
-    // Would update abuse_reports table
-    return { id, ...updates };
+    const updated = await this.updateCustomerRequest(id, {
+      message: updates.description,
+      senderEmail: updates.reporterEmail,
+      status: updates.status,
+      metadata: {
+        reportType: updates.reportType,
+        targetUrl: updates.targetUrl,
+        username: updates.username,
+        ...(updates.metadata || {}),
+      },
+    });
+
+    if (!updated) {
+      return undefined;
+    }
+
+    return {
+      id: updated.id,
+      reportType: updated.metadata?.reportType,
+      targetUrl: updated.metadata?.targetUrl,
+      description: updated.message,
+      reporterEmail: updated.senderEmail,
+      username: updated.metadata?.username,
+      status: updated.status,
+      createdAt: updated.createdAt,
+      updatedAt: updated.updatedAt,
+      pagePath: updated.pagePath,
+    };
   }
 
   // Kubernetes User Environment operations

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -173,6 +173,31 @@ export const newsletterDeliveries = pgTable("newsletter_deliveries", {
   metadata: jsonb("metadata").$type<Record<string, any>>().default({}),
 });
 
+export const customerRequests = pgTable("customer_requests", {
+  id: serial("id").primaryKey(),
+  formType: varchar("form_type", { length: 64 }).notNull(),
+  pagePath: varchar("page_path", { length: 255 }).notNull(),
+  senderName: varchar("sender_name", { length: 255 }),
+  senderEmail: varchar("sender_email", { length: 320 }),
+  senderCompany: varchar("sender_company", { length: 255 }),
+  senderPhone: varchar("sender_phone", { length: 50 }),
+  subject: varchar("subject", { length: 255 }),
+  message: text("message"),
+  status: varchar("status", { length: 32 }).notNull().default('new'),
+  metadata: jsonb("metadata").$type<Record<string, any>>().default({}),
+  createdAt: timestamp("created_at").defaultNow(),
+  updatedAt: timestamp("updated_at").defaultNow(),
+  resolvedAt: timestamp("resolved_at"),
+});
+
+export const insertCustomerRequestSchema = createInsertSchema(customerRequests, {
+  metadata: z
+    .object({})
+    .catchall(z.any())
+    .optional(),
+  status: z.enum(['new', 'in_progress', 'resolved', 'archived']).optional(),
+});
+
 // Usage tracking table for billing
 export const usageTracking = pgTable("usage_tracking", {
   id: integer("id").primaryKey().generatedByDefaultAsIdentity(),


### PR DESCRIPTION
## Summary
- persist all inbound form submissions in a new `customer_requests` table and extend storage helpers
- wire Contact Sales, Support, and Abuse forms to include full metadata and new admin APIs for viewing/updating requests
- add an admin "Customer Requests" dashboard for reviewing and triaging submissions with status controls

## Testing
- `npm run lint` *(fails: script not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68f4eb372ecc8320af613397ae35c884