### PR TITLE
Fix admin authorization for form requests API

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -21811,8 +21811,9 @@ Generate a comprehensive application based on the user's request. Include all ne
 
   // Admin - view customer form requests
   app.get('/api/admin/form-requests', ensureAuthenticated, async (req, res) => {
-    const isAdminUser = req.user?.role === 'admin' || req.user?.email?.includes('admin');
-    if (!isAdminUser) {
+    const userId = req.user?.id;
+    const user = userId ? await storage.getUser(userId) : null;
+    if (!user || user.role !== 'admin') {
       return res.status(403).json({ error: 'Admin access required' });
     }
 
@@ -21833,8 +21834,9 @@ Generate a comprehensive application based on the user's request. Include all ne
   });
 
   app.patch('/api/admin/form-requests/:id', ensureAuthenticated, async (req, res) => {
-    const isAdminUser = req.user?.role === 'admin' || req.user?.email?.includes('admin');
-    if (!isAdminUser) {
+    const userId = req.user?.id;
+    const user = userId ? await storage.getUser(userId) : null;
+    if (!user || user.role !== 'admin') {
       return res.status(403).json({ error: 'Admin access required' });
     }
 


### PR DESCRIPTION
## Summary
- fetch the authenticated user record for admin form request endpoints
- allow access only when the persisted role is admin, removing the insecure email substring check

## Testing
- not run (relevant automated tests not provided)


------
https://chatgpt.com/codex/tasks/task_e_68f5078a0450832093b4bb67a60b599b