### PR TITLE
Improve light theme styling for marketing pages

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -157,18 +157,19 @@
   }
 
   .bg-marketing-surface {
-    @apply bg-slate-950 text-slate-50;
+    background: var(--marketing-surface-bg);
+    color: var(--marketing-surface-text);
   }
 
   .glass-panel {
-    background-color: rgba(15, 23, 42, 0.6);
-    border: 1px solid rgba(148, 163, 184, 0.2);
-    box-shadow: 0 20px 45px -25px rgba(15, 23, 42, 0.6);
+    background-color: var(--marketing-glass-bg);
+    border: 1px solid var(--marketing-glass-border);
+    box-shadow: var(--marketing-glass-shadow);
     backdrop-filter: blur(24px);
   }
 
   .glass-border {
-    border-color: rgba(148, 163, 184, 0.3);
+    border-color: var(--marketing-glass-border);
   }
 }
 
@@ -218,9 +219,7 @@
 .marketing-backdrop {
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.18), transparent 55%),
-    radial-gradient(circle at top right, rgba(59, 130, 246, 0.15), transparent 50%),
-    linear-gradient(180deg, rgba(15, 23, 42, 0.9), rgba(2, 6, 23, 0.92));
+  background: var(--marketing-backdrop);
   filter: blur(40px);
   opacity: 0.9;
   z-index: 0;
@@ -229,9 +228,7 @@
 .marketing-gradient {
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 20% 20%, rgba(125, 211, 252, 0.12), transparent 45%),
-    radial-gradient(circle at 80% 20%, rgba(147, 197, 253, 0.12), transparent 50%),
-    radial-gradient(circle at 50% 70%, rgba(129, 140, 248, 0.1), transparent 40%);
+  background: var(--marketing-gradient);
   pointer-events: none;
   z-index: 0;
 }
@@ -240,14 +237,14 @@
   position: absolute;
   inset: 0;
   background-size: 56px 56px;
-  background-image: linear-gradient(to right, rgba(148, 163, 184, 0.07) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(148, 163, 184, 0.07) 1px, transparent 1px);
+  background-image: linear-gradient(to right, var(--marketing-grid-line) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--marketing-grid-line) 1px, transparent 1px);
   mask-image: radial-gradient(circle at center, black, transparent 75%);
   pointer-events: none;
 }
 
 .marketing-divider {
-  background: linear-gradient(90deg, rgba(59, 130, 246, 0), rgba(59, 130, 246, 0.3), rgba(59, 130, 246, 0));
+  background: var(--marketing-divider);
   height: 1px;
 }
 

--- a/client/src/styles/replit-theme.css
+++ b/client/src/styles/replit-theme.css
@@ -86,6 +86,21 @@
   --ecode-shadow-md: 0 20px 45px -20px rgba(15, 23, 42, 0.3);
   --ecode-shadow-lg: 0 35px 65px -30px rgba(15, 23, 42, 0.35);
 
+  /* Marketing surfaces */
+  --marketing-surface-bg: linear-gradient(180deg, #f8fbff 0%, #eef3ff 100%);
+  --marketing-surface-text: #0f172a;
+  --marketing-backdrop: radial-gradient(circle at top left, rgba(59, 130, 246, 0.18), transparent 55%),
+    radial-gradient(circle at top right, rgba(15, 118, 110, 0.12), transparent 50%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(226, 232, 240, 0.94));
+  --marketing-gradient: radial-gradient(circle at 20% 20%, rgba(14, 165, 233, 0.12), transparent 55%),
+    radial-gradient(circle at 80% 15%, rgba(59, 130, 246, 0.14), transparent 50%),
+    radial-gradient(circle at 50% 75%, rgba(99, 102, 241, 0.12), transparent 45%);
+  --marketing-grid-line: rgba(148, 163, 184, 0.12);
+  --marketing-divider: linear-gradient(90deg, rgba(59, 130, 246, 0), rgba(59, 130, 246, 0.2), rgba(59, 130, 246, 0));
+  --marketing-glass-bg: rgba(255, 255, 255, 0.65);
+  --marketing-glass-border: rgba(148, 163, 184, 0.35);
+  --marketing-glass-shadow: 0 24px 48px -32px rgba(15, 23, 42, 0.25);
+
   /* Spacing - Replit system */
   --ecode-space-1: 4px;
   --ecode-space-2: 8px;
@@ -195,6 +210,21 @@
   --ecode-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3);
   --ecode-shadow-md: 0 4px 6px rgba(0, 0, 0, 0.4);
   --ecode-shadow-lg: 0 10px 20px rgba(0, 0, 0, 0.5);
+
+  /* Marketing surfaces */
+  --marketing-surface-bg: linear-gradient(180deg, #020617 0%, #0f172a 100%);
+  --marketing-surface-text: #e2e8f0;
+  --marketing-backdrop: radial-gradient(circle at top left, rgba(56, 189, 248, 0.18), transparent 55%),
+    radial-gradient(circle at top right, rgba(59, 130, 246, 0.15), transparent 50%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.9), rgba(2, 6, 23, 0.92));
+  --marketing-gradient: radial-gradient(circle at 20% 20%, rgba(125, 211, 252, 0.12), transparent 45%),
+    radial-gradient(circle at 80% 20%, rgba(147, 197, 253, 0.12), transparent 50%),
+    radial-gradient(circle at 50% 70%, rgba(129, 140, 248, 0.1), transparent 40%);
+  --marketing-grid-line: rgba(148, 163, 184, 0.07);
+  --marketing-divider: linear-gradient(90deg, rgba(59, 130, 246, 0), rgba(59, 130, 246, 0.3), rgba(59, 130, 246, 0));
+  --marketing-glass-bg: rgba(15, 23, 42, 0.6);
+  --marketing-glass-border: rgba(148, 163, 184, 0.2);
+  --marketing-glass-shadow: 0 20px 45px -25px rgba(15, 23, 42, 0.6);
 }
 
 /* Keeping light mode selector for compatibility */


### PR DESCRIPTION
## Summary
- add dedicated marketing surface design tokens to the shared theme
- switch marketing layout utilities to consume the theme variables so light mode matches the brand styling

## Testing
- npm run lint *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68f50bc1f9e8832092a3d54e56122f85