### PR TITLE
Stabilize test harness hooks and deduplicate globals

### DIFF
--- a/test/ai-ux-features.test.ts
+++ b/test/ai-ux-features.test.ts
@@ -85,6 +85,8 @@ testRunner.registerSuite('AI UX Feature Flags', {
       },
     },
   ],
+});
+
 testRunner.registerSuite('AI UX Features', {
   tests: [],
 });

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -7,8 +7,9 @@ import {
   fileUploadSecurity,
   apiKeyValidation,
   securityMonitoring,
-  ipSecurity
+  ipSecurity,
 } from '../server/middleware/security';
+import { securityScanner } from '../server/security/security-scanner';
 
 function createResponse() {
   return {
@@ -254,7 +255,7 @@ testRunner.registerSuite('Security Middleware', {
       },
     },
   ],
-import { securityScanner } from '../server/security/security-scanner';
+});
 
 testRunner.registerSuite('Security Scanner', {
   tests: [
@@ -301,9 +302,5 @@ testRunner.registerSuite('Security Scanner', {
         expect(recommendations).toContain('Use environment variables for sensitive configuration');
       }
     }
-  ]
-});
-
-testRunner.registerSuite('Security', {
-  tests: []
+  ],
 });

--- a/test/setup/globals.ts
+++ b/test/setup/globals.ts
@@ -1,3 +1,5 @@
+import util from 'node:util';
+
 import { deepEqual, matchObject } from './utils';
 
 declare global {
@@ -5,345 +7,146 @@ declare global {
   var expect: ReturnType<typeof createExpect>;
 }
 
+type Primitive = string | number | boolean | bigint | symbol | null | undefined;
+
+type Matcher = {
+  toBe(expected: Primitive): void;
+  toEqual(expected: unknown): void;
+  toBeDefined(): void;
+  toBeTruthy(): void;
+  toBeFalsy(): void;
+  toContain(expected: unknown): void;
+  toHaveLength(expected: number): void;
+  toMatchObject(expected: Record<string, unknown>): void;
+  toBeInstanceOf(expected: new (...args: any[]) => any): void;
+  toBeGreaterThan(expected: number): void;
+  toBeGreaterThanOrEqual(expected: number): void;
+  toBeLessThan(expected: number): void;
+  toBeLessThanOrEqual(expected: number): void;
+  toThrow(message?: string | RegExp): void;
+};
+
+const formatValue = (value: unknown): string =>
+  typeof value === 'string' ? `"${value}"` : util.inspect(value, { depth: 4, colors: false });
+
 function createExpect() {
-  const expectFn = (actual: unknown) => {
-    const assertionError = (message: string): never => {
-      throw new Error(message);
+  const expectFn = (actual: unknown): Matcher => {
+    const assert = (condition: boolean, message: string): void => {
+      if (!condition) {
+        throw new Error(message);
+      }
     };
 
-    const api = {
-      toBe(expected: unknown) {
-        if (!Object.is(actual, expected)) {
-          assertionError(`Expected ${JSON.stringify(actual)} to be ${JSON.stringify(expected)}`);
-        }
+    return {
+      toBe(expected) {
+        assert(Object.is(actual, expected), `Expected ${formatValue(actual)} to be ${formatValue(expected)}`);
       },
-      toEqual(expected: unknown) {
-        if (!deepEqual(actual, expected)) {
-          assertionError(`Expected ${JSON.stringify(actual)} to deeply equal ${JSON.stringify(expected)}`);
-        }
+      toEqual(expected) {
+        assert(
+          deepEqual(actual, expected),
+          `Expected ${formatValue(actual)} to deeply equal ${formatValue(expected)}`,
+        );
+      },
+      toBeDefined() {
+        assert(actual !== undefined, 'Expected value to be defined');
       },
       toBeTruthy() {
-        if (!actual) {
-          assertionError(`Expected value to be truthy but received ${JSON.stringify(actual)}`);
-        }
+        assert(Boolean(actual), `Expected ${formatValue(actual)} to be truthy`);
       },
       toBeFalsy() {
-        if (actual) {
-          assertionError(`Expected value to be falsy but received ${JSON.stringify(actual)}`);
-        }
+        assert(!actual, `Expected ${formatValue(actual)} to be falsy`);
       },
-      toContain(expected: unknown) {
+      toContain(expected) {
         if (typeof actual === 'string') {
-          if (!actual.includes(String(expected))) {
-            assertionError(`Expected string to contain ${String(expected)}, got ${actual}`);
-          }
+          assert(actual.includes(String(expected)), `Expected ${formatValue(actual)} to contain ${formatValue(expected)}`);
           return;
         }
 
         if (Array.isArray(actual)) {
-          if (!actual.some(item => deepEqual(item, expected))) {
-            assertionError(`Expected array to contain ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
-          }
+          assert(
+            actual.some((item) => deepEqual(item, expected)),
+            `Expected ${formatValue(actual)} to contain ${formatValue(expected)}`,
+          );
           return;
         }
 
-        assertionError('toContain is only supported for strings and arrays');
+        throw new Error('toContain is only supported for strings and arrays');
       },
-      toHaveLength(expected: number) {
-        const length = (actual as any)?.length;
-        if (length !== expected) {
-          assertionError(`Expected length ${expected}, got ${length}`);
-        }
+      toHaveLength(expectedLength) {
+        const length = (actual as { length?: number })?.length;
+        assert(
+          typeof length === 'number' && length === expectedLength,
+          `Expected length ${expectedLength}, got ${length}`,
+        );
       },
-      toMatchObject(expected: Record<string, unknown>) {
+      toMatchObject(expected) {
         if (typeof actual !== 'object' || actual === null) {
-          assertionError('toMatchObject requires an object value');
+          throw new Error('toMatchObject requires an object value');
         }
 
-        if (!matchObject(actual as Record<string, unknown>, expected)) {
-          assertionError(`Expected object to match ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
-        }
+        assert(
+          matchObject(actual as Record<string, unknown>, expected),
+          `Expected object to match ${formatValue(expected)}, got ${formatValue(actual)}`,
+        );
       },
-      toBeInstanceOf(expected: new (...args: any[]) => any) {
-        if (!(actual instanceof expected)) {
-          const name = expected?.name ?? 'constructor';
-          assertionError(`Expected value to be instance of ${name}`);
-        }
+      toBeInstanceOf(expected) {
+        assert(actual instanceof expected, `Expected value to be instance of ${expected?.name ?? 'constructor'}`);
       },
-      toBeDefined() {
-        if (typeof actual === 'undefined') {
-          assertionError('Expected value to be defined');
-        }
+      toBeGreaterThan(expected) {
+        assert(typeof actual === 'number', 'toBeGreaterThan matcher requires a numeric actual value');
+        assert((actual as number) > expected, `Expected ${formatValue(actual)} to be greater than ${formatValue(expected)}`);
       },
-      toThrow(message?: string | RegExp) {
+      toBeGreaterThanOrEqual(expected) {
+        assert(typeof actual === 'number', 'toBeGreaterThanOrEqual matcher requires a numeric actual value');
+        assert(
+          (actual as number) >= expected,
+          `Expected ${formatValue(actual)} to be greater than or equal to ${formatValue(expected)}`,
+        );
+      },
+      toBeLessThan(expected) {
+        assert(typeof actual === 'number', 'toBeLessThan matcher requires a numeric actual value');
+        assert((actual as number) < expected, `Expected ${formatValue(actual)} to be less than ${formatValue(expected)}`);
+      },
+      toBeLessThanOrEqual(expected) {
+        assert(typeof actual === 'number', 'toBeLessThanOrEqual matcher requires a numeric actual value');
+        assert(
+          (actual as number) <= expected,
+          `Expected ${formatValue(actual)} to be less than or equal to ${formatValue(expected)}`,
+        );
+      },
+      toThrow(message) {
         if (typeof actual !== 'function') {
-          assertionError('toThrow expects a function');
+          throw new Error('toThrow expects a function');
         }
 
         let didThrow = false;
         try {
-          actual();
+          (actual as () => unknown)();
         } catch (error) {
           didThrow = true;
           if (message) {
             const text = error instanceof Error ? error.message : String(error);
             if (message instanceof RegExp) {
-              if (!message.test(text)) {
-                assertionError(`Expected error message to match ${message}, got ${text}`);
-              }
-            } else if (text !== message) {
-              assertionError(`Expected error message to be ${message}, got ${text}`);
+              assert(message.test(text), `Expected error message to match ${message}, got ${text}`);
+            } else {
+              assert(text === message, `Expected error message to be ${message}, got ${text}`);
             }
           }
         }
 
-        if (!didThrow) {
-          assertionError('Expected function to throw');
-        }
+        assert(didThrow, 'Expected function to throw');
       },
-    } as const;
-
-    return api;
+    } satisfies Matcher;
   };
 
   return expectFn;
 }
 
 export function setupTestGlobals(): void {
-  if (!(globalThis as any).expect) {
+  if (!(globalThis as { expect?: ReturnType<typeof createExpect> }).expect) {
     (globalThis as any).expect = createExpect();
   }
 }
-import assert from 'node:assert/strict';
 
-type Primitive = string | number | boolean | bigint | symbol | null | undefined;
-
-type Matcher = {
-  toBe: (expected: Primitive) => void;
-  toEqual: (expected: unknown) => void;
-  toBeTruthy: () => void;
-  toBeFalsy: () => void;
-  toContain: (expected: unknown) => void;
-  toBeGreaterThan: (expected: number) => void;
-  toBeGreaterThanOrEqual: (expected: number) => void;
-  toBeLessThan: (expected: number) => void;
-  toBeLessThanOrEqual: (expected: number) => void;
-};
-
-class Expectation implements Matcher {
-  constructor(private readonly received: unknown) {}
-
-  toBe(expected: Primitive) {
-    assert.strictEqual(this.received as Primitive, expected);
-  }
-
-  toEqual(expected: unknown) {
-    assert.deepStrictEqual(this.received, expected);
-  }
-
-  toBeTruthy() {
-    assert.ok(this.received, `Expected value to be truthy but received ${this.received}`);
-  }
-
-  toBeFalsy() {
-    assert.ok(!this.received, `Expected value to be falsy but received ${this.received}`);
-  }
-
-  toContain(expected: unknown) {
-    if (typeof this.received === 'string' && typeof expected === 'string') {
-      assert.ok(this.received.includes(expected), `Expected "${this.received}" to contain "${expected}"`);
-      return;
-    }
-
-    if (Array.isArray(this.received)) {
-      assert.ok(this.received.some((item) => Object.is(item, expected)), 'Expected array to contain value');
-      return;
-    }
-
-    throw new TypeError('toContain matcher expects a string or array received value');
-  }
-
-  toBeGreaterThan(expected: number) {
-    assert.ok((this.received as number) > expected, `Expected value to be greater than ${expected}`);
-  }
-
-  toBeGreaterThanOrEqual(expected: number) {
-    assert.ok((this.received as number) >= expected, `Expected value to be >= ${expected}`);
-  }
-
-  toBeLessThan(expected: number) {
-    assert.ok((this.received as number) < expected, `Expected value to be less than ${expected}`);
-  }
-
-  toBeLessThanOrEqual(expected: number) {
-    assert.ok((this.received as number) <= expected, `Expected value to be <= ${expected}`);
-  }
-}
-
-export function setupTestGlobals() {
-  (globalThis as any).expect = (received: unknown): Matcher => new Expectation(received);
-}
-
+export type ExpectFn = ReturnType<typeof createExpect>;
 export type { Matcher };
-import util from 'node:util';
-
-type Primitive = string | number | boolean | bigint | symbol | null | undefined;
-
-type Expectation<T> = {
-  toBe(expected: T): void;
-  toEqual(expected: unknown): void;
-  toBeDefined(): void;
-  toBeTruthy(): void;
-  toBeFalsy(): void;
-  toContain(expected: unknown): void;
-  toBeGreaterThan(expected: number): void;
-  toBeGreaterThanOrEqual(expected: number): void;
-  toBeLessThan(expected: number): void;
-  toBeLessThanOrEqual(expected: number): void;
-};
-
-const isPrimitive = (value: unknown): value is Primitive =>
-  (value !== Object(value)) || typeof value === 'symbol';
-
-const deepEqual = (a: unknown, b: unknown, seen = new WeakMap<object, object>()): boolean => {
-  if (Object.is(a, b)) {
-    return true;
-  }
-
-  if (typeof a !== typeof b) {
-    return false;
-  }
-
-  if (a === null || b === null) {
-    return a === b;
-  }
-
-  if (isPrimitive(a) || isPrimitive(b)) {
-    return a === b;
-  }
-
-  if (Array.isArray(a) && Array.isArray(b)) {
-    if (a.length !== b.length) {
-      return false;
-    }
-
-    return a.every((item, index) => deepEqual(item, b[index], seen));
-  }
-
-  if (typeof a === 'object' && typeof b === 'object') {
-    const objA = a as Record<string | symbol, unknown>;
-    const objB = b as Record<string | symbol, unknown>;
-
-    if (seen.get(objA) === objB) {
-      return true;
-    }
-    seen.set(objA, objB);
-
-    const keysA = Reflect.ownKeys(objA);
-    const keysB = Reflect.ownKeys(objB);
-
-    if (keysA.length !== keysB.length) {
-      return false;
-    }
-
-    return keysA.every((key) => deepEqual(objA[key], objB[key], seen));
-  }
-
-  return false;
-};
-
-function createExpectation<T>(actual: T): Expectation<T> {
-  return {
-    toBe(expected) {
-      if (!Object.is(actual, expected)) {
-        throw new Error(`Expected ${formatValue(actual)} to be ${formatValue(expected)}`);
-      }
-    },
-    toEqual(expected) {
-      if (!deepEqual(actual, expected)) {
-        throw new Error(`Expected ${formatValue(actual)} to equal ${formatValue(expected)}`);
-      }
-    },
-    toBeDefined() {
-      if (actual === undefined) {
-        throw new Error('Expected value to be defined');
-      }
-    },
-    toBeTruthy() {
-      if (!actual) {
-        throw new Error(`Expected ${formatValue(actual)} to be truthy`);
-      }
-    },
-    toBeFalsy() {
-      if (actual) {
-        throw new Error(`Expected ${formatValue(actual)} to be falsy`);
-      }
-    },
-    toContain(expected) {
-      if (typeof (actual as unknown as { includes?: (item: unknown) => boolean }).includes === 'function') {
-        if (!(actual as unknown as { includes: (item: unknown) => boolean }).includes(expected)) {
-          throw new Error(`Expected ${formatValue(actual)} to contain ${formatValue(expected)}`);
-        }
-        return;
-      }
-
-      if (Array.isArray(actual)) {
-        if (!actual.some((item) => deepEqual(item, expected))) {
-          throw new Error(`Expected ${formatValue(actual)} to contain ${formatValue(expected)}`);
-        }
-        return;
-      }
-
-      throw new Error('toContain matcher requires an array or value supporting includes');
-    },
-    toBeGreaterThan(expected) {
-      if (typeof actual !== 'number') {
-        throw new Error('toBeGreaterThan matcher requires a numeric actual value');
-      }
-      if (!(actual > expected)) {
-        throw new Error(`Expected ${formatValue(actual)} to be greater than ${formatValue(expected)}`);
-      }
-    },
-    toBeGreaterThanOrEqual(expected) {
-      if (typeof actual !== 'number') {
-        throw new Error('toBeGreaterThanOrEqual matcher requires a numeric actual value');
-      }
-      if (!(actual >= expected)) {
-        throw new Error(`Expected ${formatValue(actual)} to be greater than or equal to ${formatValue(expected)}`);
-      }
-    },
-    toBeLessThan(expected) {
-      if (typeof actual !== 'number') {
-        throw new Error('toBeLessThan matcher requires a numeric actual value');
-      }
-      if (!(actual < expected)) {
-        throw new Error(`Expected ${formatValue(actual)} to be less than ${formatValue(expected)}`);
-      }
-    },
-    toBeLessThanOrEqual(expected) {
-      if (typeof actual !== 'number') {
-        throw new Error('toBeLessThanOrEqual matcher requires a numeric actual value');
-      }
-      if (!(actual <= expected)) {
-        throw new Error(`Expected ${formatValue(actual)} to be less than or equal to ${formatValue(expected)}`);
-      }
-    },
-  };
-}
-
-const formatValue = (value: unknown): string =>
-  typeof value === 'string' ? `'${value}'` : util.inspect(value, { depth: 4, colors: false });
-
-export type ExpectFn = <T>(actual: T) => Expectation<T>;
-
-export const setupTestGlobals = (): void => {
-  const expectFn: ExpectFn = (actual) => createExpectation(actual);
-
-  Object.assign(globalThis, {
-    expect: expectFn,
-  });
-};
-
-export type GlobalExpect = typeof globalThis & {
-  expect: ExpectFn;
-};

--- a/test/setup/test-runner.ts
+++ b/test/setup/test-runner.ts
@@ -1,71 +1,3 @@
-import path from 'node:path';
-
-export interface TestCase {
-  name: string;
-  fn: () => void | Promise<void>;
-}
-
-export interface TestSuite {
-  tests: TestCase[];
-  beforeAll?: () => void | Promise<void>;
-  afterAll?: () => void | Promise<void>;
-}
-
-interface RegisteredSuite extends TestSuite {
-  name: string;
-  file?: string;
-}
-
-interface TestResults {
-  total: number;
-  passed: number;
-  failed: number;
-  skipped: number;
-}
-
-class TestRunner {
-  private suites: RegisteredSuite[] = [];
-
-  registerSuite(name: string, suite: TestSuite): void {
-    let file: string | undefined;
-
-    const stack = new Error().stack?.split('\n') ?? [];
-    for (const line of stack) {
-      const match = line.match(/((?:[A-Za-z]:)?[\\/][^:]+?\.(?:test|spec)\.[tj]sx?)/i);
-      if (match) {
-        const resolved = match[1];
-        const relative = path.relative(process.cwd(), resolved);
-        file = relative || resolved;
-        break;
-      }
-    }
-
-    this.suites.push({ name, file, ...suite });
-  }
-
-  async run(pattern?: string): Promise<TestResults> {
-    const escapeRegex = (value: string) =>
-      value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
-    const matcher = pattern ? new RegExp(escapeRegex(pattern), 'i') : null;
-    let total = 0;
-    let passed = 0;
-    let failed = 0;
-    let skipped = 0;
-
-    for (const suite of this.suites) {
-      const suiteMatches = matcher
-        ? matcher.test(suite.name) || (suite.file ? matcher.test(suite.file) : false)
-        : true;
-
-      if (matcher && !suiteMatches) {
-        const hasMatchingTest = suite.tests.some(test => matcher.test(test.name));
-        if (!hasMatchingTest) {
-          skipped += suite.tests.length;
-          continue;
-        }
-      }
-
-      console.log(`\nSuite: ${suite.name}`);
 import { performance } from 'node:perf_hooks';
 
 type MaybePromise<T> = T | Promise<T>;
@@ -113,6 +45,14 @@ const hasFocusedTests = (): boolean =>
 
 const formatDuration = (ms: number): string => `${ms.toFixed(0)}ms`;
 
+const logError = (error: unknown): void => {
+  if (error instanceof Error) {
+    console.error(error.stack ?? error.message);
+  } else {
+    console.error(error);
+  }
+};
+
 export const testRunner = {
   registerSuite(name: string, suite: TestSuite): void {
     registeredSuites.push({ name, suite });
@@ -143,75 +83,67 @@ export const testRunner = {
       console.log(`\nSuite: ${suiteName}`);
 
       if (suite.beforeAll) {
-        await suite.beforeAll();
+        try {
+          await suite.beforeAll();
+        } catch (error) {
+          failed += 1;
+          console.error('  ✗ beforeAll hook failed');
+          logError(error);
+          // Continue with remaining suites/tests despite beforeAll failure.
+        }
       }
 
-      for (const test of suite.tests) {
-        if (
-          matcher &&
-          !matcher.test(test.name) &&
-          !matcher.test(suite.name) &&
-          !(suite.file && matcher.test(suite.file))
-        ) {
-          skipped += 1;
-          continue;
-        }
-
-        total += 1;
-        const start = Date.now();
       for (const test of tests) {
-        if (suite.beforeEach) {
-          await suite.beforeEach();
-        }
-
         const started = performance.now();
+        const errors: unknown[] = [];
 
-        try {
-          await test.fn();
-          passed += 1;
-          console.log(`  ✓ ${test.name} (${Date.now() - start}ms)`);
-        } catch (error) {
-          failed += 1;
-          console.error(`  ✗ ${test.name}`);
-          if (error instanceof Error) {
-            console.error(`    ${error.message}`);
-            if (error.stack) {
-              console.error(error.stack.split('\n').slice(1).map(line => `    ${line.trim()}`).join('\n'));
-            }
-          } else {
-            console.error(`    ${String(error)}`);
+        if (suite.beforeEach) {
+          try {
+            await suite.beforeEach();
+          } catch (error) {
+            errors.push(error);
           }
         }
-          const duration = performance.now() - started;
-          console.log(`  ✓ ${test.name} (${formatDuration(duration)})`);
-        } catch (error) {
-          failed += 1;
-          const duration = performance.now() - started;
-          console.error(`  ✗ ${test.name} (${formatDuration(duration)})`);
-          if (error instanceof Error) {
-            console.error(error.stack ?? error.message);
-          } else {
-            console.error(error);
+
+        if (errors.length === 0) {
+          try {
+            await test.fn();
+          } catch (error) {
+            errors.push(error);
           }
         }
 
         if (suite.afterEach) {
-          await suite.afterEach();
+          try {
+            await suite.afterEach();
+          } catch (error) {
+            errors.push(error);
+          }
+        }
+
+        const duration = performance.now() - started;
+
+        if (errors.length > 0) {
+          failed += 1;
+          console.error(`  ✗ ${test.name} (${formatDuration(duration)})`);
+          errors.forEach((error) => logError(error));
+        } else {
+          passed += 1;
+          console.log(`  ✓ ${test.name} (${formatDuration(duration)})`);
         }
       }
 
       if (suite.afterAll) {
-        await suite.afterAll();
+        try {
+          await suite.afterAll();
+        } catch (error) {
+          failed += 1;
+          console.error('  ✗ afterAll hook failed');
+          logError(error);
+        }
       }
     }
 
-    console.log(`\nTest Results: ${passed} passed, ${failed} failed, ${skipped} skipped`);
-
-    return { total, passed, failed, skipped };
-  }
-}
-
-export const testRunner = new TestRunner();
     console.log(`\nTest Results: ${passed} passed, ${failed} failed`);
 
     return { failed, passed };


### PR DESCRIPTION
## Summary
- replace the duplicated `setupTestGlobals` implementations with a single matcher suite that covers all existing assertions
- fix the security and AI UX test suites so they close before registering additional suites, restoring valid TypeScript
- ensure the security scanner tests import ordering stays at the top level for the consolidated runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f50793d64c8320b1ede4fa9d854226