### PR TITLE
Fix test harness path resolution and clean test suites

### DIFF
--- a/test/ai-ux-features.test.ts
+++ b/test/ai-ux-features.test.ts
@@ -85,6 +85,4 @@ testRunner.registerSuite('AI UX Feature Flags', {
       },
     },
   ],
-testRunner.registerSuite('AI UX Features', {
-  tests: [],
 });

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -7,8 +7,9 @@ import {
   fileUploadSecurity,
   apiKeyValidation,
   securityMonitoring,
-  ipSecurity
+  ipSecurity,
 } from '../server/middleware/security';
+import { securityScanner } from '../server/security/security-scanner';
 
 function createResponse() {
   return {
@@ -157,16 +158,16 @@ testRunner.registerSuite('Security Middleware', {
     {
       name: 'apiKeyValidation enforces presence and minimum length',
       fn: () => {
-        const res = createResponse();
+        const resMissing = createResponse();
         const reqMissing: any = { headers: {} };
         let nextCalled = false;
 
-        apiKeyValidation(reqMissing, res, () => {
+        apiKeyValidation(reqMissing, resMissing, () => {
           nextCalled = true;
         });
 
-        expect(res.statusCode).toBe(401);
-        expect((res.body as any)?.error).toBe('API key required');
+        expect(resMissing.statusCode).toBe(401);
+        expect((resMissing.body as any)?.error).toBe('API key required');
         expect(nextCalled).toBe(false);
 
         const resInvalid = createResponse();
@@ -254,7 +255,7 @@ testRunner.registerSuite('Security Middleware', {
       },
     },
   ],
-import { securityScanner } from '../server/security/security-scanner';
+});
 
 testRunner.registerSuite('Security Scanner', {
   tests: [
@@ -267,7 +268,7 @@ testRunner.registerSuite('Security Scanner', {
         expect(Array.isArray(issues)).toBeTruthy();
         expect(issues.length).toBeGreaterThan(0);
         expect(issues[0].type).toBe('secret');
-      }
+      },
     },
     {
       name: 'scanProject aggregates issue severities',
@@ -275,22 +276,22 @@ testRunner.registerSuite('Security Scanner', {
         const result = await securityScanner.scanProject(42, [
           {
             path: 'src/index.ts',
-            content: `const password = "supersecret";\n// TODO: tighten security\nconsole.log('debug');`
+            content: `const password = "supersecret";\n// TODO: tighten security\nconsole.log('debug');`,
           },
           {
             path: 'src/app.ts',
-            content: `fetch('https://example.com/data');\nconst token = 'ghp_${'A'.repeat(36)}';`
-          }
+            content: `fetch('https://example.com/data');\nconst token = 'ghp_${'A'.repeat(36)}';`,
+          },
         ]);
 
-        const severities = new Set(result.issues.map((issue) => issue.severity));
+        const severities = new Set(result.issues.map(issue => issue.severity));
 
         expect(result.projectId).toBe(42);
         expect(result.summary.totalIssues).toBe(result.issues.length);
         expect(severities.has('critical')).toBeTruthy();
         expect(severities.size).toBeGreaterThan(1);
         expect(result.summary.totalIssues).toBeGreaterThan(3);
-      }
+      },
     },
     {
       name: 'getSecurityRecommendations returns actionable guidance',
@@ -299,10 +300,7 @@ testRunner.registerSuite('Security Scanner', {
 
         expect(recommendations.length).toBeGreaterThan(0);
         expect(recommendations).toContain('Use environment variables for sensitive configuration');
-      }
-    }
-  ]
-
-testRunner.registerSuite('Security', {
-  tests: [],
+      },
+    },
+  ],
 });

--- a/test/setup/globals.ts
+++ b/test/setup/globals.ts
@@ -1,3 +1,5 @@
+import util from 'node:util';
+
 import { deepEqual, matchObject } from './utils';
 
 declare global {
@@ -5,105 +7,127 @@ declare global {
   var expect: ReturnType<typeof createExpect>;
 }
 
+type Constructor = new (...args: any[]) => unknown;
+
+type ExpectApi = {
+  toBe(expected: unknown): void;
+  toEqual(expected: unknown): void;
+  toBeTruthy(): void;
+  toBeFalsy(): void;
+  toContain(expected: unknown): void;
+  toHaveLength(expected: number): void;
+  toMatchObject(expected: Record<string, unknown>): void;
+  toBeInstanceOf(expected: Constructor): void;
+  toBeDefined(): void;
+  toThrow(message?: string | RegExp): void;
+  toBeGreaterThan(expected: number): void;
+  toBeGreaterThanOrEqual(expected: number): void;
+  toBeLessThan(expected: number): void;
+  toBeLessThanOrEqual(expected: number): void;
+};
+
+const formatValue = (value: unknown): string =>
+  typeof value === 'string' ? `'${value}'` : util.inspect(value, { depth: 4, colors: false });
+
 function createExpect() {
-  const expectFn = (actual: unknown) => {
-    const assertionError = (message: string): never => {
-      throw new Error(message);
+  const expectFn = (actual: unknown): ExpectApi => {
+    const assert = (condition: unknown, message: string): asserts condition => {
+      if (!condition) {
+        throw new Error(message);
+      }
     };
 
-    const api = {
-      toBe(expected: unknown) {
-        if (!Object.is(actual, expected)) {
-          assertionError(`Expected ${JSON.stringify(actual)} to be ${JSON.stringify(expected)}`);
-        }
+    return {
+      toBe(expected) {
+        assert(Object.is(actual, expected), `Expected ${formatValue(actual)} to be ${formatValue(expected)}`);
       },
-      toEqual(expected: unknown) {
-        if (!deepEqual(actual, expected)) {
-          assertionError(`Expected ${JSON.stringify(actual)} to deeply equal ${JSON.stringify(expected)}`);
-        }
+      toEqual(expected) {
+        assert(
+          deepEqual(actual, expected),
+          `Expected ${formatValue(actual)} to deeply equal ${formatValue(expected)}`,
+        );
       },
       toBeTruthy() {
-        if (!actual) {
-          assertionError(`Expected value to be truthy but received ${JSON.stringify(actual)}`);
-        }
+        assert(Boolean(actual), `Expected value to be truthy but received ${formatValue(actual)}`);
       },
       toBeFalsy() {
-        if (actual) {
-          assertionError(`Expected value to be falsy but received ${JSON.stringify(actual)}`);
-        }
+        assert(!actual, `Expected value to be falsy but received ${formatValue(actual)}`);
       },
-      toContain(expected: unknown) {
+      toContain(expected) {
         if (typeof actual === 'string') {
-          if (!actual.includes(String(expected))) {
-            assertionError(`Expected string to contain ${String(expected)}, got ${actual}`);
-          }
+          assert(
+            actual.includes(String(expected)),
+            `Expected string ${formatValue(actual)} to contain ${formatValue(expected)}`,
+          );
           return;
         }
 
         if (Array.isArray(actual)) {
-          if (!actual.some(item => deepEqual(item, expected))) {
-            assertionError(`Expected array to contain ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
-          }
+          assert(
+            actual.some(item => deepEqual(item, expected)),
+            `Expected array ${formatValue(actual)} to contain ${formatValue(expected)}`,
+          );
           return;
         }
 
-        assertionError('toContain is only supported for strings and arrays');
+        throw new Error('toContain is only supported for strings and arrays');
       },
-      toHaveLength(expected: number) {
-        const length = (actual as any)?.length;
-        if (length !== expected) {
-          assertionError(`Expected length ${expected}, got ${length}`);
-        }
+      toHaveLength(expected) {
+        const length = (actual as { length?: unknown })?.length;
+        assert(typeof length === 'number', 'toHaveLength matcher expects a value with a numeric length property');
+        assert(length === expected, `Expected length ${expected}, got ${length}`);
       },
-      toMatchObject(expected: Record<string, unknown>) {
-        if (typeof actual !== 'object' || actual === null) {
-          assertionError('toMatchObject requires an object value');
-        }
-
-        if (!matchObject(actual as Record<string, unknown>, expected)) {
-          assertionError(`Expected object to match ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
-        }
+      toMatchObject(expected) {
+        assert(typeof actual === 'object' && actual !== null, 'toMatchObject requires an object value');
+        assert(
+          matchObject(actual as Record<string, unknown>, expected),
+          `Expected object to match ${formatValue(expected)}, got ${formatValue(actual)}`,
+        );
       },
-      toBeInstanceOf(expected: new (...args: any[]) => any) {
-        if (!(actual instanceof expected)) {
-          const name = expected?.name ?? 'constructor';
-          assertionError(`Expected value to be instance of ${name}`);
-        }
+      toBeInstanceOf(expected) {
+        assert(typeof expected === 'function', 'toBeInstanceOf requires a constructor function');
+        assert(actual instanceof expected, `Expected value to be instance of ${expected.name || 'constructor'}`);
       },
       toBeDefined() {
-        if (typeof actual === 'undefined') {
-          assertionError('Expected value to be defined');
-        }
+        assert(typeof actual !== 'undefined', 'Expected value to be defined');
       },
-      toThrow(message?: string | RegExp) {
-        if (typeof actual !== 'function') {
-          assertionError('toThrow expects a function');
-        }
+      toThrow(message) {
+        assert(typeof actual === 'function', 'toThrow expects a function');
 
         let didThrow = false;
         try {
-          actual();
+          (actual as () => unknown)();
         } catch (error) {
           didThrow = true;
           if (message) {
             const text = error instanceof Error ? error.message : String(error);
             if (message instanceof RegExp) {
-              if (!message.test(text)) {
-                assertionError(`Expected error message to match ${message}, got ${text}`);
-              }
-            } else if (text !== message) {
-              assertionError(`Expected error message to be ${message}, got ${text}`);
+              assert(message.test(text), `Expected error message to match ${message}, got ${text}`);
+            } else {
+              assert(text === message, `Expected error message to be ${message}, got ${text}`);
             }
           }
         }
 
-        if (!didThrow) {
-          assertionError('Expected function to throw');
-        }
+        assert(didThrow, 'Expected function to throw');
       },
-    } as const;
-
-    return api;
+      toBeGreaterThan(expected) {
+        assert(typeof actual === 'number', 'toBeGreaterThan expects a number');
+        assert((actual as number) > expected, `Expected ${actual} to be greater than ${expected}`);
+      },
+      toBeGreaterThanOrEqual(expected) {
+        assert(typeof actual === 'number', 'toBeGreaterThanOrEqual expects a number');
+        assert((actual as number) >= expected, `Expected ${actual} to be greater than or equal to ${expected}`);
+      },
+      toBeLessThan(expected) {
+        assert(typeof actual === 'number', 'toBeLessThan expects a number');
+        assert((actual as number) < expected, `Expected ${actual} to be less than ${expected}`);
+      },
+      toBeLessThanOrEqual(expected) {
+        assert(typeof actual === 'number', 'toBeLessThanOrEqual expects a number');
+        assert((actual as number) <= expected, `Expected ${actual} to be less than or equal to ${expected}`);
+      },
+    };
   };
 
   return expectFn;
@@ -114,200 +138,5 @@ export function setupTestGlobals(): void {
     (globalThis as any).expect = createExpect();
   }
 }
-import assert from 'node:assert/strict';
 
-type Primitive = string | number | boolean | bigint | symbol | null | undefined;
-
-type Matcher = {
-  toBe: (expected: Primitive) => void;
-  toEqual: (expected: unknown) => void;
-  toBeTruthy: () => void;
-  toBeFalsy: () => void;
-  toContain: (expected: unknown) => void;
-  toBeGreaterThan: (expected: number) => void;
-  toBeGreaterThanOrEqual: (expected: number) => void;
-  toBeLessThan: (expected: number) => void;
-  toBeLessThanOrEqual: (expected: number) => void;
-};
-
-class Expectation implements Matcher {
-  constructor(private readonly received: unknown) {}
-
-  toBe(expected: Primitive) {
-    assert.strictEqual(this.received as Primitive, expected);
-  }
-
-  toEqual(expected: unknown) {
-    assert.deepStrictEqual(this.received, expected);
-  }
-
-  toBeTruthy() {
-    assert.ok(this.received, `Expected value to be truthy but received ${this.received}`);
-  }
-
-  toBeFalsy() {
-    assert.ok(!this.received, `Expected value to be falsy but received ${this.received}`);
-  }
-
-  toContain(expected: unknown) {
-    if (typeof this.received === 'string' && typeof expected === 'string') {
-      assert.ok(this.received.includes(expected), `Expected "${this.received}" to contain "${expected}"`);
-      return;
-    }
-
-    if (Array.isArray(this.received)) {
-      assert.ok(this.received.some((item) => Object.is(item, expected)), 'Expected array to contain value');
-      return;
-    }
-
-    throw new TypeError('toContain matcher expects a string or array received value');
-  }
-
-  toBeGreaterThan(expected: number) {
-    assert.ok((this.received as number) > expected, `Expected value to be greater than ${expected}`);
-  }
-
-  toBeGreaterThanOrEqual(expected: number) {
-    assert.ok((this.received as number) >= expected, `Expected value to be >= ${expected}`);
-  }
-
-  toBeLessThan(expected: number) {
-    assert.ok((this.received as number) < expected, `Expected value to be less than ${expected}`);
-  }
-
-  toBeLessThanOrEqual(expected: number) {
-    assert.ok((this.received as number) <= expected, `Expected value to be <= ${expected}`);
-  }
-}
-
-export function setupTestGlobals() {
-  (globalThis as any).expect = (received: unknown): Matcher => new Expectation(received);
-}
-
-export type { Matcher };
-import util from 'node:util';
-
-type Primitive = string | number | boolean | bigint | symbol | null | undefined;
-
-type Expectation<T> = {
-  toBe(expected: T): void;
-  toEqual(expected: unknown): void;
-  toBeDefined(): void;
-  toBeTruthy(): void;
-  toBeFalsy(): void;
-  toContain(expected: unknown): void;
-};
-
-const isPrimitive = (value: unknown): value is Primitive =>
-  (value !== Object(value)) || typeof value === 'symbol';
-
-const deepEqual = (a: unknown, b: unknown, seen = new WeakMap<object, object>()): boolean => {
-  if (Object.is(a, b)) {
-    return true;
-  }
-
-  if (typeof a !== typeof b) {
-    return false;
-  }
-
-  if (a === null || b === null) {
-    return a === b;
-  }
-
-  if (isPrimitive(a) || isPrimitive(b)) {
-    return a === b;
-  }
-
-  if (Array.isArray(a) && Array.isArray(b)) {
-    if (a.length !== b.length) {
-      return false;
-    }
-
-    return a.every((item, index) => deepEqual(item, b[index], seen));
-  }
-
-  if (typeof a === 'object' && typeof b === 'object') {
-    const objA = a as Record<string | symbol, unknown>;
-    const objB = b as Record<string | symbol, unknown>;
-
-    if (seen.get(objA) === objB) {
-      return true;
-    }
-    seen.set(objA, objB);
-
-    const keysA = Reflect.ownKeys(objA);
-    const keysB = Reflect.ownKeys(objB);
-
-    if (keysA.length !== keysB.length) {
-      return false;
-    }
-
-    return keysA.every((key) => deepEqual(objA[key], objB[key], seen));
-  }
-
-  return false;
-};
-
-function createExpectation<T>(actual: T): Expectation<T> {
-  return {
-    toBe(expected) {
-      if (!Object.is(actual, expected)) {
-        throw new Error(`Expected ${formatValue(actual)} to be ${formatValue(expected)}`);
-      }
-    },
-    toEqual(expected) {
-      if (!deepEqual(actual, expected)) {
-        throw new Error(`Expected ${formatValue(actual)} to equal ${formatValue(expected)}`);
-      }
-    },
-    toBeDefined() {
-      if (actual === undefined) {
-        throw new Error('Expected value to be defined');
-      }
-    },
-    toBeTruthy() {
-      if (!actual) {
-        throw new Error(`Expected ${formatValue(actual)} to be truthy`);
-      }
-    },
-    toBeFalsy() {
-      if (actual) {
-        throw new Error(`Expected ${formatValue(actual)} to be falsy`);
-      }
-    },
-    toContain(expected) {
-      if (typeof (actual as unknown as { includes?: (item: unknown) => boolean }).includes === 'function') {
-        if (!(actual as unknown as { includes: (item: unknown) => boolean }).includes(expected)) {
-          throw new Error(`Expected ${formatValue(actual)} to contain ${formatValue(expected)}`);
-        }
-        return;
-      }
-
-      if (Array.isArray(actual)) {
-        if (!actual.some((item) => deepEqual(item, expected))) {
-          throw new Error(`Expected ${formatValue(actual)} to contain ${formatValue(expected)}`);
-        }
-        return;
-      }
-
-      throw new Error('toContain matcher requires an array or value supporting includes');
-    },
-  };
-}
-
-const formatValue = (value: unknown): string =>
-  typeof value === 'string' ? `'${value}'` : util.inspect(value, { depth: 4, colors: false });
-
-export type ExpectFn = <T>(actual: T) => Expectation<T>;
-
-export const setupTestGlobals = (): void => {
-  const expectFn: ExpectFn = (actual) => createExpectation(actual);
-
-  Object.assign(globalThis, {
-    expect: expectFn,
-  });
-};
-
-export type GlobalExpect = typeof globalThis & {
-  expect: ExpectFn;
-};
+export type ExpectFn = ReturnType<typeof createExpect>;

--- a/test/setup/test-runner.ts
+++ b/test/setup/test-runner.ts
@@ -1,152 +1,155 @@
 import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+
+const STACK_PATH_PATTERN =
+  /((?:file:\/\/\/|file:\/\/)?(?:[A-Za-z]:)?[\\/]?[^()\r\n:]+?(?:[\\/][^()\r\n:]+)*\.(?:test|spec)\.[tj]sx?)/i;
 
 export interface TestCase {
   name: string;
   fn: () => void | Promise<void>;
+  timeoutMs?: number;
+  skip?: boolean;
+  only?: boolean;
 }
 
-export interface TestSuite {
-  tests: TestCase[];
+export interface SuiteLifecycle {
   beforeAll?: () => void | Promise<void>;
   afterAll?: () => void | Promise<void>;
+  beforeEach?: () => void | Promise<void>;
+  afterEach?: () => void | Promise<void>;
 }
 
-interface RegisteredSuite extends TestSuite {
+export interface TestSuite extends SuiteLifecycle {
+  tests: TestCase[];
+}
+
+interface RegisteredSuite {
   name: string;
+  suite: TestSuite;
   file?: string;
 }
 
-interface TestResults {
+export interface TestResults {
   total: number;
   passed: number;
   failed: number;
   skipped: number;
 }
 
+const escapeRegex = (value: string) => value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+
 class TestRunner {
   private suites: RegisteredSuite[] = [];
 
-  registerSuite(name: string, suite: TestSuite): void {
-    let file: string | undefined;
+  private inferSuiteFile(): string | undefined {
+    const stackLines = new Error().stack?.split('\n') ?? [];
 
-    const stack = new Error().stack?.split('\n') ?? [];
-    for (const line of stack) {
-      const match = line.match(/((?:[A-Za-z]:)?[\\/][^:]+?\.(?:test|spec)\.[tj]sx?)/i);
-      if (match) {
-        const resolved = match[1];
-        const relative = path.relative(process.cwd(), resolved);
-        file = relative || resolved;
-        break;
+    for (const line of stackLines) {
+      const match = line.match(STACK_PATH_PATTERN);
+      if (!match) {
+        continue;
       }
+
+      let rawPath = match[1];
+      if (/^file:\/\//i.test(rawPath)) {
+        try {
+          rawPath = fileURLToPath(rawPath);
+        } catch (error) {
+          console.error('Failed to normalize file URL from stack trace:', error);
+          continue;
+        }
+      }
+
+      const absolute = path.isAbsolute(rawPath)
+        ? rawPath
+        : path.resolve(process.cwd(), rawPath);
+      const normalized = path.normalize(absolute);
+      const relative = path.relative(process.cwd(), normalized);
+
+      return relative || normalized;
     }
 
-    this.suites.push({ name, file, ...suite });
+    return undefined;
+  }
+
+  registerSuite(name: string, suite: TestSuite): void {
+    const file = this.inferSuiteFile();
+    this.suites.push({ name, suite, file });
   }
 
   async run(pattern?: string): Promise<TestResults> {
-    const escapeRegex = (value: string) =>
-      value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
     const matcher = pattern ? new RegExp(escapeRegex(pattern), 'i') : null;
+    const matchesPattern = (value?: string) => {
+      if (!matcher || !value) {
+        return false;
+      }
+
+      return new RegExp(matcher.source, matcher.flags).test(value);
+    };
+    const hasFocusedTests = this.suites.some((entry) =>
+      entry.suite.tests.some((test) => test.only),
+    );
+
     let total = 0;
     let passed = 0;
     let failed = 0;
     let skipped = 0;
 
-    for (const suite of this.suites) {
-      const suiteMatches = matcher
-        ? matcher.test(suite.name) || (suite.file ? matcher.test(suite.file) : false)
-        : true;
+    for (const entry of this.suites) {
+      const { name, suite, file } = entry;
+      const suiteMatches = matcher ? matchesPattern(name) || matchesPattern(file) : true;
 
-      if (matcher && !suiteMatches) {
-        const hasMatchingTest = suite.tests.some(test => matcher.test(test.name));
-        if (!hasMatchingTest) {
-          skipped += suite.tests.length;
+      const runnableTests: TestCase[] = [];
+
+      for (const test of suite.tests) {
+        if (test.skip) {
+          skipped += 1;
           continue;
         }
+
+        if (hasFocusedTests && !test.only) {
+          skipped += 1;
+          continue;
+        }
+
+        const shouldRun = !matcher || matchesPattern(test.name) || suiteMatches;
+
+        if (!shouldRun) {
+          skipped += 1;
+          continue;
+        }
+
+        runnableTests.push(test);
       }
 
-      console.log(`\nSuite: ${suite.name}`);
-import { performance } from 'node:perf_hooks';
-
-type TestFn = () => void | Promise<void>;
-
-type HookFn = () => void | Promise<void>;
-
-interface TestCase {
-  name: string;
-  fn: TestFn;
-  timeoutMs?: number;
-}
-
-interface SuiteDefinition {
-  tests: TestCase[];
-  beforeAll?: HookFn;
-  afterAll?: HookFn;
-  beforeEach?: HookFn;
-  afterEach?: HookFn;
-}
-
-interface SuiteRegistration {
-  name: string;
-  definition: SuiteDefinition;
-}
-
-interface TestResultSummary {
-  total: number;
-  passed: number;
-  failed: number;
-  durationMs: number;
-}
-
-class TestRunner {
-  private suites: SuiteRegistration[] = [];
-
-  registerSuite(name: string, definition: SuiteDefinition) {
-    this.suites.push({ name, definition });
-  }
-
-  async run(pattern?: string): Promise<TestResultSummary> {
-    const startTime = performance.now();
-    const matcher = pattern ? new RegExp(pattern, 'i') : null;
-
-    let total = 0;
-    let passed = 0;
-    let failed = 0;
-
-    for (const suite of this.suites) {
-      const { name, definition } = suite;
-      const testsToRun = definition.tests.filter((test) => {
-        if (!matcher) return true;
-        return matcher.test(name) || matcher.test(test.name);
-      });
-
-      if (testsToRun.length === 0) {
+      if (runnableTests.length === 0) {
         continue;
       }
 
       console.log(`\nSuite: ${name}`);
 
-      if (definition.beforeAll) {
-        await definition.beforeAll();
+      if (suite.beforeAll) {
+        await suite.beforeAll();
       }
 
-      for (const test of testsToRun) {
+      for (const test of runnableTests) {
         total += 1;
-        const testStart = performance.now();
+        const start = performance.now();
         const timeout = test.timeoutMs ?? 5000;
         let timer: NodeJS.Timeout | undefined;
 
         try {
           await Promise.race([
             (async () => {
-              if (definition.beforeEach) {
-                await definition.beforeEach();
+              if (suite.beforeEach) {
+                await suite.beforeEach();
               }
 
               await test.fn();
 
-              if (definition.afterEach) {
-                await definition.afterEach();
+              if (suite.afterEach) {
+                await suite.afterEach();
               }
             })(),
             new Promise<never>((_, reject) => {
@@ -157,162 +160,21 @@ class TestRunner {
           ]);
 
           passed += 1;
-          const testDuration = performance.now() - testStart;
-          console.log(`  ✓ ${test.name} (${testDuration.toFixed(2)}ms)`);
+          const duration = performance.now() - start;
+          console.log(`  ✓ ${test.name} (${duration.toFixed(2)}ms)`);
         } catch (error) {
           failed += 1;
-          const testDuration = performance.now() - testStart;
-          console.error(`  ✗ ${test.name} (${testDuration.toFixed(2)}ms)`);
-          console.error(`    ${error instanceof Error ? error.stack ?? error.message : error}`);
+          const duration = performance.now() - start;
+          console.error(`  ✗ ${test.name} (${duration.toFixed(2)}ms)`);
+          if (error instanceof Error) {
+            console.error(`    ${error.stack ?? error.message}`);
+          } else {
+            console.error(`    ${String(error)}`);
+          }
         } finally {
           if (timer) {
             clearTimeout(timer);
           }
-        }
-      }
-
-      if (definition.afterAll) {
-        await definition.afterAll();
-      }
-    }
-
-    const durationMs = performance.now() - startTime;
-    console.log(`\nTest Summary: ${passed}/${total} passed${failed ? `, ${failed} failed` : ''}. (${durationMs.toFixed(2)}ms)`);
-
-    return { total, passed, failed, durationMs };
-  }
-}
-
-export const testRunner = new TestRunner();
-type MaybePromise<T> = T | Promise<T>;
-
-export type TestCase = {
-  name: string;
-  fn: () => MaybePromise<void>;
-  skip?: boolean;
-  only?: boolean;
-};
-
-export type SuiteLifecycle = {
-  beforeAll?: () => MaybePromise<void>;
-  afterAll?: () => MaybePromise<void>;
-  beforeEach?: () => MaybePromise<void>;
-  afterEach?: () => MaybePromise<void>;
-};
-
-export type TestSuite = SuiteLifecycle & {
-  tests: TestCase[];
-};
-
-type RegisteredSuite = {
-  name: string;
-  suite: TestSuite;
-};
-
-const registeredSuites: RegisteredSuite[] = [];
-
-const matchesPattern = (name: string, pattern?: string): boolean => {
-  if (!pattern) {
-    return true;
-  }
-
-  const normalized = pattern.trim().toLowerCase();
-  if (!normalized) {
-    return true;
-  }
-
-  return name.toLowerCase().includes(normalized);
-};
-
-const hasFocusedTests = (): boolean =>
-  registeredSuites.some((entry) => entry.suite.tests.some((test) => test.only));
-
-const formatDuration = (ms: number): string => `${ms.toFixed(0)}ms`;
-
-export const testRunner = {
-  registerSuite(name: string, suite: TestSuite): void {
-    registeredSuites.push({ name, suite });
-  },
-
-  async run(pattern?: string): Promise<{ failed: number; passed: number }> {
-    let failed = 0;
-    let passed = 0;
-    const focused = hasFocusedTests();
-
-    for (const { name: suiteName, suite } of registeredSuites) {
-      const tests = suite.tests.filter((test) => {
-        if (focused && !test.only) {
-          return false;
-        }
-
-        if (test.skip) {
-          return false;
-        }
-
-        return matchesPattern(`${suiteName} ${test.name}`, pattern);
-      });
-
-      if (tests.length === 0) {
-        continue;
-      }
-
-      console.log(`\nSuite: ${suiteName}`);
-
-      if (suite.beforeAll) {
-        await suite.beforeAll();
-      }
-
-      for (const test of suite.tests) {
-        if (
-          matcher &&
-          !matcher.test(test.name) &&
-          !matcher.test(suite.name) &&
-          !(suite.file && matcher.test(suite.file))
-        ) {
-          skipped += 1;
-          continue;
-        }
-
-        total += 1;
-        const start = Date.now();
-      for (const test of tests) {
-        if (suite.beforeEach) {
-          await suite.beforeEach();
-        }
-
-        const started = performance.now();
-
-        try {
-          await test.fn();
-          passed += 1;
-          console.log(`  ✓ ${test.name} (${Date.now() - start}ms)`);
-        } catch (error) {
-          failed += 1;
-          console.error(`  ✗ ${test.name}`);
-          if (error instanceof Error) {
-            console.error(`    ${error.message}`);
-            if (error.stack) {
-              console.error(error.stack.split('\n').slice(1).map(line => `    ${line.trim()}`).join('\n'));
-            }
-          } else {
-            console.error(`    ${String(error)}`);
-          }
-        }
-          const duration = performance.now() - started;
-          console.log(`  ✓ ${test.name} (${formatDuration(duration)})`);
-        } catch (error) {
-          failed += 1;
-          const duration = performance.now() - started;
-          console.error(`  ✗ ${test.name} (${formatDuration(duration)})`);
-          if (error instanceof Error) {
-            console.error(error.stack ?? error.message);
-          } else {
-            console.error(error);
-          }
-        }
-
-        if (suite.afterEach) {
-          await suite.afterEach();
         }
       }
 
@@ -328,10 +190,3 @@ export const testRunner = {
 }
 
 export const testRunner = new TestRunner();
-    console.log(`\nTest Results: ${passed} passed, ${failed} failed`);
-
-    return { failed, passed };
-  },
-};
-
-export type TestRunner = typeof testRunner;


### PR DESCRIPTION
## Summary
- rewrite the custom test runner to normalize Windows and file URL stack paths, honor skip/only flags, and apply literal pattern filtering while keeping timing and hooks support
- consolidate the bespoke expect helpers into a single implementation that covers the matchers used by the suites
- restore the security and AI UX feature tests to valid modules so they register their suites without stray imports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f507a43b7c8320880160e505187d88