### PR TITLE
Fix partial community profile updates

### DIFF
--- a/server/community/community-service.ts
+++ b/server/community/community-service.ts
@@ -648,17 +648,32 @@ export class CommunityService {
 
       const { displayName, bio, website, githubUsername, twitterUsername, profileImageUrl } = req.body;
 
+      const updateData: Partial<typeof users.$inferInsert> = {
+        updatedAt: new Date(),
+      };
+
+      if (displayName !== undefined) {
+        updateData.displayName = displayName;
+      }
+      if (bio !== undefined) {
+        updateData.bio = bio;
+      }
+      if (website !== undefined) {
+        updateData.website = website;
+      }
+      if (githubUsername !== undefined) {
+        updateData.githubUsername = githubUsername;
+      }
+      if (twitterUsername !== undefined) {
+        updateData.twitterUsername = twitterUsername;
+      }
+      if (profileImageUrl !== undefined) {
+        updateData.profileImageUrl = profileImageUrl;
+      }
+
       await db
         .update(users)
-        .set({
-          displayName,
-          bio,
-          website,
-          githubUsername,
-          twitterUsername,
-          profileImageUrl,
-          updatedAt: new Date(),
-        })
+        .set(updateData)
         .where(eq(users.id, userId));
 
       res.json({ success: true });


### PR DESCRIPTION
## Summary
- guard the community profile update to only set fields provided in the request
- ensure existing profile values are preserved when requests omit a field

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f5106e97a083208f6b224f919cbbf0