### PR TITLE
Fix notification preference FK type mismatch

### DIFF
--- a/migrations/0002_notifications_system.sql
+++ b/migrations/0002_notifications_system.sql
@@ -4,6 +4,21 @@ ALTER TABLE "push_notifications"
   ADD COLUMN IF NOT EXISTS "read" boolean NOT NULL DEFAULT false,
   ADD COLUMN IF NOT EXISTS "read_at" timestamp;
 
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'notification_preferences'
+      AND column_name = 'user_id'
+      AND data_type <> 'integer'
+  ) THEN
+    ALTER TABLE "notification_preferences"
+      ALTER COLUMN "user_id" TYPE integer USING "user_id"::integer;
+  END IF;
+END $$;
+
 CREATE TABLE IF NOT EXISTS "notification_preferences" (
   -- match users.id integer type to keep the foreign key valid
   "user_id" integer PRIMARY KEY,


### PR DESCRIPTION
## Summary
- ensure the notification preferences table always uses an integer user_id column
- add a guard block to coerce any preexisting notification_preferences.user_id values to integer before recreating the table

## Testing
- not run (migration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f5109924248320aa745a6eb8e79e8e