### PR TITLE
Align notification preferences foreign key with users.id

### DIFF
--- a/migrations/0002_notifications_system.sql
+++ b/migrations/0002_notifications_system.sql
@@ -15,3 +15,45 @@ CREATE TABLE IF NOT EXISTS "notification_preferences" (
   CONSTRAINT "notification_preferences_user_id_users_id_fk" FOREIGN KEY ("user_id")
     REFERENCES "users" ("id") ON DELETE cascade ON UPDATE no action
 );
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'notification_preferences'
+      AND column_name = 'user_id'
+      AND data_type <> 'integer'
+  ) THEN
+    ALTER TABLE "notification_preferences"
+      ALTER COLUMN "user_id" TYPE integer USING "user_id"::integer;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_name = 'notification_preferences'
+  ) THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM information_schema.table_constraints
+      WHERE table_name = 'notification_preferences'
+        AND constraint_name = 'notification_preferences_user_id_users_id_fk'
+    ) THEN
+      ALTER TABLE "notification_preferences"
+        ADD CONSTRAINT "notification_preferences_user_id_users_id_fk"
+          FOREIGN KEY ("user_id") REFERENCES "users" ("id")
+          ON DELETE cascade ON UPDATE no action;
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM information_schema.table_constraints
+      WHERE table_name = 'notification_preferences'
+        AND constraint_type = 'PRIMARY KEY'
+    ) THEN
+      ALTER TABLE "notification_preferences"
+        ADD PRIMARY KEY ("user_id");
+    END IF;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- ensure legacy notification_preferences tables convert user_id to integer
- reapply the foreign key and primary key constraints if they are missing after the type correction

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f5100ebef083208655a6fe7d506266