### PR TITLE
Refine community profile partial update handling

### DIFF
--- a/server/community/community-service.ts
+++ b/server/community/community-service.ts
@@ -648,18 +648,35 @@ export class CommunityService {
 
       const { displayName, bio, website, githubUsername, twitterUsername, profileImageUrl } = req.body;
 
-      await db
-        .update(users)
-        .set({
-          displayName,
-          bio,
-          website,
-          githubUsername,
-          twitterUsername,
-          profileImageUrl,
-          updatedAt: new Date(),
-        })
-        .where(eq(users.id, userId));
+      const updateData = {
+        updatedAt: new Date(),
+      } as Partial<typeof users.$inferInsert>;
+
+      if (displayName !== undefined) {
+        updateData.displayName = displayName;
+      }
+
+      if (bio !== undefined) {
+        updateData.bio = bio;
+      }
+
+      if (website !== undefined) {
+        updateData.website = website;
+      }
+
+      if (githubUsername !== undefined) {
+        updateData.githubUsername = githubUsername;
+      }
+
+      if (twitterUsername !== undefined) {
+        updateData.twitterUsername = twitterUsername;
+      }
+
+      if (profileImageUrl !== undefined) {
+        updateData.profileImageUrl = profileImageUrl;
+      }
+
+      await db.update(users).set(updateData).where(eq(users.id, userId));
 
       res.json({ success: true });
     } catch (error) {


### PR DESCRIPTION
## Summary
- ensure community profile updates only include fields present in the request body
- rely on typed conditional assignments so optional values remain unchanged when omitted

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f50feed14c8320861a8278e2b7f5f1