### PR TITLE
Add follow-up migration for notification preference foreign key fix

### DIFF
--- a/migrations/0002_notifications_system.sql
+++ b/migrations/0002_notifications_system.sql
@@ -5,7 +5,7 @@ ALTER TABLE "push_notifications"
   ADD COLUMN IF NOT EXISTS "read_at" timestamp;
 
 CREATE TABLE IF NOT EXISTS "notification_preferences" (
-  "user_id" varchar PRIMARY KEY,
+  "user_id" integer PRIMARY KEY,
   "email" jsonb NOT NULL DEFAULT '{}'::jsonb,
   "push" jsonb NOT NULL DEFAULT '{}'::jsonb,
   "frequency" varchar NOT NULL DEFAULT 'instant',

--- a/migrations/0002_notifications_system.sql
+++ b/migrations/0002_notifications_system.sql
@@ -5,7 +5,7 @@ ALTER TABLE "push_notifications"
   ADD COLUMN IF NOT EXISTS "read_at" timestamp;
 
 CREATE TABLE IF NOT EXISTS "notification_preferences" (
-  "user_id" integer PRIMARY KEY,
+  "user_id" integer NOT NULL PRIMARY KEY,
   "email" jsonb NOT NULL DEFAULT '{}'::jsonb,
   "push" jsonb NOT NULL DEFAULT '{}'::jsonb,
   "frequency" varchar NOT NULL DEFAULT 'instant',

--- a/migrations/0002_notifications_system.sql
+++ b/migrations/0002_notifications_system.sql
@@ -5,8 +5,7 @@ ALTER TABLE "push_notifications"
   ADD COLUMN IF NOT EXISTS "read_at" timestamp;
 
 CREATE TABLE IF NOT EXISTS "notification_preferences" (
-  -- match users.id integer type to keep the foreign key valid
-  "user_id" integer PRIMARY KEY,
+  "user_id" varchar PRIMARY KEY,
   "email" jsonb NOT NULL DEFAULT '{}'::jsonb,
   "push" jsonb NOT NULL DEFAULT '{}'::jsonb,
   "frequency" varchar NOT NULL DEFAULT 'instant',
@@ -15,45 +14,3 @@ CREATE TABLE IF NOT EXISTS "notification_preferences" (
   CONSTRAINT "notification_preferences_user_id_users_id_fk" FOREIGN KEY ("user_id")
     REFERENCES "users" ("id") ON DELETE cascade ON UPDATE no action
 );
-
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1
-    FROM information_schema.columns
-    WHERE table_name = 'notification_preferences'
-      AND column_name = 'user_id'
-      AND data_type <> 'integer'
-  ) THEN
-    ALTER TABLE "notification_preferences"
-      ALTER COLUMN "user_id" TYPE integer USING "user_id"::integer;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1
-    FROM information_schema.tables
-    WHERE table_name = 'notification_preferences'
-  ) THEN
-    IF NOT EXISTS (
-      SELECT 1
-      FROM information_schema.table_constraints
-      WHERE table_name = 'notification_preferences'
-        AND constraint_name = 'notification_preferences_user_id_users_id_fk'
-    ) THEN
-      ALTER TABLE "notification_preferences"
-        ADD CONSTRAINT "notification_preferences_user_id_users_id_fk"
-          FOREIGN KEY ("user_id") REFERENCES "users" ("id")
-          ON DELETE cascade ON UPDATE no action;
-    END IF;
-
-    IF NOT EXISTS (
-      SELECT 1
-      FROM information_schema.table_constraints
-      WHERE table_name = 'notification_preferences'
-        AND constraint_type = 'PRIMARY KEY'
-    ) THEN
-      ALTER TABLE "notification_preferences"
-        ADD PRIMARY KEY ("user_id");
-    END IF;
-  END IF;
-END $$;

--- a/migrations/0003_notification_preferences_fk_fix.sql
+++ b/migrations/0003_notification_preferences_fk_fix.sql
@@ -1,0 +1,62 @@
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'notification_preferences'
+      AND column_name = 'user_id'
+      AND data_type <> 'integer'
+  ) THEN
+    -- Drop constraints that depend on the column type so it can be converted.
+    IF EXISTS (
+      SELECT 1
+      FROM information_schema.table_constraints
+      WHERE table_name = 'notification_preferences'
+        AND constraint_name = 'notification_preferences_user_id_users_id_fk'
+    ) THEN
+      ALTER TABLE "notification_preferences"
+        DROP CONSTRAINT "notification_preferences_user_id_users_id_fk";
+    END IF;
+
+    IF EXISTS (
+      SELECT 1
+      FROM information_schema.table_constraints
+      WHERE table_name = 'notification_preferences'
+        AND constraint_type = 'PRIMARY KEY'
+    ) THEN
+      ALTER TABLE "notification_preferences"
+        DROP CONSTRAINT IF EXISTS "notification_preferences_pkey";
+    END IF;
+
+    ALTER TABLE "notification_preferences"
+      ALTER COLUMN "user_id" TYPE integer USING "user_id"::integer;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_name = 'notification_preferences'
+  ) THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM information_schema.table_constraints
+      WHERE table_name = 'notification_preferences'
+        AND constraint_name = 'notification_preferences_user_id_users_id_fk'
+    ) THEN
+      ALTER TABLE "notification_preferences"
+        ADD CONSTRAINT "notification_preferences_user_id_users_id_fk"
+          FOREIGN KEY ("user_id") REFERENCES "users" ("id")
+          ON DELETE cascade ON UPDATE no action;
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM information_schema.table_constraints
+      WHERE table_name = 'notification_preferences'
+        AND constraint_type = 'PRIMARY KEY'
+    ) THEN
+      ALTER TABLE "notification_preferences"
+        ADD PRIMARY KEY ("user_id");
+    END IF;
+  END IF;
+END $$;

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -4138,7 +4138,7 @@
       "columns": {
         "user_id": {
           "name": "user_id",
-          "type": "varchar",
+          "type": "integer",
           "primaryKey": true,
           "notNull": true
         },

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1754571039706,
       "tag": "0002_notifications_system",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1754571040706,
+      "tag": "0003_notification_preferences_fk_fix",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- restore the original 0002_notifications_system migration so previously deployed environments remain valid
- add a new 0003 migration that converts notification_preferences.user_id to integer and reapplies the foreign/primary keys
- update the Drizzle migration journal and snapshot to include the new migration and schema change

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f512cab11083208375b80c197c7fbd