### PR TITLE
Allow SSE session query auth and fix package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,10 @@
     "dev": "NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
-    "check": "tsc -p tsconfig.check.json",
     "check": "npm run typecheck",
+    "check:project": "tsc -p tsconfig.check.json",
     "typecheck": "tsc --noEmit --pretty false --skipLibCheck",
     "typecheck:full": "tsc --noEmit --pretty false --skipLibCheck -p tsconfig.full.json",
-    "db:push": "drizzle-kit push"
-    "check": "tsc",
     "db:push": "drizzle-kit push",
     "test": "tsx test/run-tests.ts"
   },

--- a/server/mcp/standalone-server.ts
+++ b/server/mcp/standalone-server.ts
@@ -448,8 +448,27 @@ function removeSession(sessionId: string) {
   }
 }
 
+function getSessionIdFromQuery(query: any): string | undefined {
+  if (!query) return undefined;
+
+  const raw = query.sessionId ?? query.session_id;
+  if (Array.isArray(raw)) {
+    return raw[0];
+  }
+
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+
+  return String(raw);
+}
+
 function getSessionFromRequest(req: any) {
-  const sessionId = req.headers['x-session-id'] as string || req.body?.sessionId;
+  const headerSessionId = req.headers['x-session-id'];
+  const sessionId =
+    (Array.isArray(headerSessionId) ? headerSessionId[0] : (headerSessionId as string)) ||
+    req.body?.sessionId ||
+    getSessionIdFromQuery(req.query);
   if (!sessionId || !sessions.has(sessionId)) {
     return null;
   }


### PR DESCRIPTION
## Summary
- accept MCP session IDs from query parameters so SSE /events can authenticate EventSource clients
- clean up package.json scripts to remove duplicates and add a dedicated tsconfig check script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f5135d7bfc8320b31b43250ea478f1