### PR TITLE
Guard notification preference migration against missing table

### DIFF
--- a/migrations/0003_notification_preferences_fk_fix.sql
+++ b/migrations/0003_notification_preferences_fk_fix.sql
@@ -8,7 +8,7 @@ BEGIN
       AND column_name = 'user_id'
       AND data_type <> 'integer'
   ) THEN
-    ALTER TABLE "notification_preferences"
+    ALTER TABLE IF EXISTS public.notification_preferences
       ALTER COLUMN "user_id" TYPE integer USING "user_id"::integer;
   END IF;
 
@@ -25,9 +25,9 @@ BEGIN
         AND table_schema = 'public'
         AND constraint_name = 'notification_preferences_user_id_users_id_fk'
     ) THEN
-      ALTER TABLE "notification_preferences"
+      ALTER TABLE IF EXISTS public.notification_preferences
         ADD CONSTRAINT "notification_preferences_user_id_users_id_fk"
-          FOREIGN KEY ("user_id") REFERENCES "users" ("id")
+          FOREIGN KEY ("user_id") REFERENCES public.users ("id")
           ON DELETE cascade ON UPDATE no action;
     END IF;
 
@@ -38,7 +38,7 @@ BEGIN
         AND table_schema = 'public'
         AND constraint_type = 'PRIMARY KEY'
     ) THEN
-      ALTER TABLE "notification_preferences"
+      ALTER TABLE IF EXISTS public.notification_preferences
         ADD PRIMARY KEY ("user_id");
     END IF;
   END IF;


### PR DESCRIPTION
## Summary
- add IF EXISTS guards to each ALTER TABLE statement in the notification preference cleanup migration to ensure it only targets the public schema table

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f517d011c483209bb80812569048c1