### PR TITLE
Trim notification preference user IDs before numeric check

### DIFF
--- a/migrations/0002_notifications_system.sql
+++ b/migrations/0002_notifications_system.sql
@@ -36,7 +36,7 @@ BEGIN
         SELECT 1
         FROM "notification_preferences"
         WHERE "user_id" IS NOT NULL
-          AND "user_id" !~ '^[0-9]+$'
+          AND trim("user_id") !~ '^[0-9]+$'
       ) THEN
         RAISE EXCEPTION 'notification_preferences.user_id contains non-numeric values and cannot be cast to integer safely';
       END IF;


### PR DESCRIPTION
## Summary
- trim notification_preferences.user_id values before applying the numeric regex guard so padded digits migrate successfully

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f51c06f43883209d8084e8a0fc5831