### PR TITLE
Ensure admin role is available on authenticated requests

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -35,6 +35,7 @@ type UserForAuth = {
   username: string;
   password: string;
   email: string;
+  role: string | null;
   displayName: string | null;
   avatarUrl: string | null;
   bio: string | null;
@@ -201,6 +202,7 @@ export function setupAuth(app: Express) {
           username: user.username || '',
           password: user.password || '',
           email: user.email || '',
+          role: user.role ?? null,
           displayName: user.displayName,
           avatarUrl: user.profileImageUrl,
           bio: user.bio,
@@ -245,6 +247,7 @@ export function setupAuth(app: Express) {
         username: user.username || '',
         password: user.password || '',
         email: user.email || '',
+        role: user.role ?? null,
         displayName: user.displayName,
         avatarUrl: user.profileImageUrl,
         bio: user.bio,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -21810,17 +21810,38 @@ Generate a comprehensive application based on the user's request. Include all ne
   });
 
   // Admin - view customer form requests
-  const requireAdminAccess = (req: Request, res: Response) => {
-    if (req.user?.role === 'admin') {
-      return true;
-    }
+  const requireAdminAccess = async (req: Request, res: Response) => {
+    try {
+      const userId = req.user?.id;
 
-    res.status(403).json({ error: 'Admin access required' });
-    return false;
+      if (!userId) {
+        res.status(403).json({ error: 'Admin access required' });
+        return false;
+      }
+
+      if ((req.user as any)?.role === 'admin') {
+        return true;
+      }
+
+      const persistedUser = await storage.getUser(String(userId));
+      if (persistedUser?.role === 'admin') {
+        if (req.user) {
+          (req.user as any).role = persistedUser.role;
+        }
+        return true;
+      }
+
+      res.status(403).json({ error: 'Admin access required' });
+      return false;
+    } catch (error) {
+      logger.error('Failed to verify admin access:', error);
+      res.status(500).json({ error: 'Failed to verify admin access' });
+      return false;
+    }
   };
 
   app.get('/api/admin/form-requests', ensureAuthenticated, async (req, res) => {
-    if (!requireAdminAccess(req, res)) {
+    if (!(await requireAdminAccess(req, res))) {
       return;
     }
 
@@ -21841,7 +21862,7 @@ Generate a comprehensive application based on the user's request. Include all ne
   });
 
   app.patch('/api/admin/form-requests/:id', ensureAuthenticated, async (req, res) => {
-    if (!requireAdminAccess(req, res)) {
+    if (!(await requireAdminAccess(req, res))) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- include the persisted user role on the Express session user so admin checks can use req.user.role
- refresh the form-request admin guard to persist the fetched role back onto the request user object

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f517ec2e988320ac9466c81cc3fb10