### PR TITLE
Ensure notification preference IDs infer as strings

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -434,7 +434,8 @@ export const pushNotifications = pgTable("push_notifications", {
 });
 
 export const notificationPreferences = pgTable("notification_preferences", {
-  userId: integer("user_id")
+  userId: varchar("user_id")
+    .$type<string>()
     .primaryKey()
     .references(() => users.id, { onDelete: 'cascade' }),
   email: jsonb("email").$type<Record<string, boolean>>().notNull().default({}),


### PR DESCRIPTION
## Summary
- explicitly type the notification preference userId column as a string to keep Drizzle inference aligned with string user IDs

## Testing
- npm test *(fails: `ipSecurity blocks blacklisted addresses` ReferenceError: nextCalled is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68f51bfcf3f883209b6dc756775ae4fb