### PR TITLE
Address Codex review feedback: normalize test runner path filtering

### DIFF
--- a/test/setup/test-runner.ts
+++ b/test/setup/test-runner.ts
@@ -29,17 +29,19 @@ type RegisteredSuite = {
 
 const registeredSuites: RegisteredSuite[] = [];
 
+const normalizeSeparators = (value: string): string => value.replace(/\\/g, '/');
+
 const matchesPattern = (name: string, pattern?: string): boolean => {
   if (!pattern) {
     return true;
   }
 
-  const normalized = pattern.trim().toLowerCase();
-  if (!normalized) {
+  const normalizedPattern = normalizeSeparators(pattern.trim()).toLowerCase();
+  if (!normalizedPattern) {
     return true;
   }
 
-  return name.toLowerCase().includes(normalized);
+  return normalizeSeparators(name).toLowerCase().includes(normalizedPattern);
 };
 
 const extractFilePathFromStack = (): string | undefined => {
@@ -66,11 +68,13 @@ const extractFilePathFromStack = (): string | undefined => {
       }
     }
 
-    if (candidate.includes('test/setup/test-runner')) {
+    const normalizedCandidate = normalizeSeparators(candidate);
+
+    if (normalizedCandidate.includes('test/setup/test-runner')) {
       continue;
     }
 
-    return candidate;
+    return normalizedCandidate;
   }
 
   return undefined;


### PR DESCRIPTION
## Summary
- normalize stack frame paths before filtering out the runner file itself
- compare normalized file paths and pattern inputs when matching suites

## Testing
- npm test -- test/security.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f51fcbc60083209dbc6a5e95398103