### PR TITLE
Add migration to convert notification preference user IDs to text

### DIFF
--- a/migrations/0004_notification_preferences_user_id_to_varchar.sql
+++ b/migrations/0004_notification_preferences_user_id_to_varchar.sql
@@ -1,0 +1,40 @@
+-- Convert notification_preferences.user_id to varchar to match users.id
+DO $$
+DECLARE
+  constraint_exists BOOLEAN;
+BEGIN
+  -- Only run if the column exists and isn't already character varying
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'notification_preferences'
+      AND column_name = 'user_id'
+      AND data_type <> 'character varying'
+  ) THEN
+    -- Drop foreign key constraint if it exists to allow type change
+    SELECT EXISTS (
+      SELECT 1
+      FROM information_schema.table_constraints
+      WHERE table_schema = 'public'
+        AND table_name = 'notification_preferences'
+        AND constraint_name = 'notification_preferences_user_id_users_id_fk'
+    ) INTO constraint_exists;
+
+    IF constraint_exists THEN
+      ALTER TABLE "notification_preferences"
+        DROP CONSTRAINT "notification_preferences_user_id_users_id_fk";
+    END IF;
+
+    ALTER TABLE "notification_preferences"
+      ALTER COLUMN "user_id" TYPE varchar USING "user_id"::text;
+
+    ALTER TABLE "notification_preferences"
+      ALTER COLUMN "user_id" SET NOT NULL;
+
+    ALTER TABLE "notification_preferences"
+      ADD CONSTRAINT "notification_preferences_user_id_users_id_fk"
+        FOREIGN KEY ("user_id") REFERENCES "users" ("id")
+        ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -4138,7 +4138,7 @@
       "columns": {
         "user_id": {
           "name": "user_id",
-          "type": "integer",
+          "type": "varchar",
           "primaryKey": true,
           "notNull": true
         },

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1754571040706,
       "tag": "0003_align_notification_preferences_user_id",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1754571041706,
+      "tag": "0004_notification_preferences_user_id_to_varchar",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a migration to convert `notification_preferences.user_id` to `varchar` and reapply the foreign key
- update the Drizzle journal and snapshot so metadata matches the new column type

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5203d1d988320a1ebd7fc74e471ca