### PR TITLE
Address numeric notification user IDs

### DIFF
--- a/server/routes/notifications.ts
+++ b/server/routes/notifications.ts
@@ -33,18 +33,33 @@ const normalizeNotificationResponse = (notification: any) => {
   };
 };
 
-const getUserIdOrThrow = (req: any, res: any): string | null => {
-  const userId = req.user?.id;
-  if (!userId) {
+const getUserIdOrThrow = (req: any, res: any): number | null => {
+  const rawUserId = req.user?.id;
+  if (rawUserId === undefined || rawUserId === null) {
     res.status(401).json({ message: 'Not authenticated' });
     return null;
   }
-  return typeof userId === 'string' ? userId : String(userId);
+
+  if (typeof rawUserId === 'number') {
+    if (Number.isInteger(rawUserId)) {
+      return rawUserId;
+    }
+    res.status(400).json({ message: 'Invalid user session' });
+    return null;
+  }
+
+  const normalized = Number.parseInt(String(rawUserId).trim(), 10);
+  if (!Number.isInteger(normalized)) {
+    res.status(400).json({ message: 'Invalid user session' });
+    return null;
+  }
+
+  return normalized;
 };
 
 const getPreferencesHandler = async (req: any, res: any) => {
   const userId = getUserIdOrThrow(req, res);
-  if (!userId) return;
+  if (userId === null) return;
 
   try {
     const preferences = await storage.getNotificationPreferences(userId);
@@ -57,7 +72,7 @@ const getPreferencesHandler = async (req: any, res: any) => {
 
 const updatePreferencesHandler = async (req: any, res: any) => {
   const userId = getUserIdOrThrow(req, res);
-  if (!userId) return;
+  if (userId === null) return;
 
   try {
     const parsed = notificationSettingsUpdateSchema.parse(req.body ?? {});
@@ -77,7 +92,7 @@ const updatePreferencesHandler = async (req: any, res: any) => {
 router.get('/api/notifications', ensureAuthenticated, async (req, res) => {
   try {
     const userId = getUserIdOrThrow(req, res);
-    if (!userId) return;
+    if (userId === null) return;
 
     const unreadParam = req.query.unread;
     const unreadOnly = unreadParam === 'true' || unreadParam === '1';
@@ -94,7 +109,7 @@ router.get('/api/notifications', ensureAuthenticated, async (req, res) => {
 router.get('/api/notifications/unread-count', ensureAuthenticated, async (req, res) => {
   try {
     const userId = getUserIdOrThrow(req, res);
-    if (!userId) return;
+    if (userId === null) return;
 
     const count = await storage.getUnreadNotificationCount(userId);
     res.json({ count });
@@ -118,7 +133,7 @@ router.put('/api/notifications/settings', ensureAuthenticated, updatePreferences
 const markNotificationAsReadHandler = async (req: any, res: any) => {
   try {
     const userId = getUserIdOrThrow(req, res);
-    if (!userId) return;
+    if (userId === null) return;
 
     const notificationId = parseInt(req.params.id, 10);
     if (Number.isNaN(notificationId)) {
@@ -140,7 +155,7 @@ router.put('/api/notifications/:id/read', ensureAuthenticated, markNotificationA
 const markAllNotificationsAsReadHandler = async (req: any, res: any) => {
   try {
     const userId = getUserIdOrThrow(req, res);
-    if (!userId) return;
+    if (userId === null) return;
 
     await storage.markAllNotificationsAsRead(userId);
     res.json({ success: true });
@@ -157,7 +172,7 @@ router.put('/api/notifications/read-all', ensureAuthenticated, markAllNotificati
 router.delete('/api/notifications/:id', ensureAuthenticated, async (req, res) => {
   try {
     const userId = getUserIdOrThrow(req, res);
-    if (!userId) return;
+    if (userId === null) return;
 
     const notificationId = parseInt(req.params.id, 10);
     if (isNaN(notificationId)) {
@@ -176,7 +191,7 @@ router.delete('/api/notifications/:id', ensureAuthenticated, async (req, res) =>
 router.delete('/api/notifications', ensureAuthenticated, async (req, res) => {
   try {
     const userId = getUserIdOrThrow(req, res);
-    if (!userId) return;
+    if (userId === null) return;
 
     await storage.deleteAllNotifications(userId);
     res.json({ success: true });
@@ -190,7 +205,7 @@ router.delete('/api/notifications', ensureAuthenticated, async (req, res) => {
 router.post('/api/notifications', ensureAuthenticated, async (req, res) => {
   try {
     const userId = getUserIdOrThrow(req, res);
-    if (!userId) return;
+    if (userId === null) return;
 
     const payload = {
       ...req.body,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -162,8 +162,26 @@ const DEFAULT_NOTIFICATION_PREFERENCES: {
   frequency: 'instant',
 };
 
-const normalizeUserId = (userId: string | number): string =>
-  typeof userId === 'string' ? userId : String(userId);
+const normalizeUserId = (userId: string | number): number => {
+  if (typeof userId === 'number') {
+    if (Number.isInteger(userId)) {
+      return userId;
+    }
+    throw new TypeError('User ID must be an integer');
+  }
+
+  const trimmed = userId.trim();
+  if (!/^-?\d+$/.test(trimmed)) {
+    throw new TypeError('Invalid user ID format');
+  }
+
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed)) {
+    throw new TypeError('Invalid user ID value');
+  }
+
+  return parsed;
+};
 
 const normalizePreferenceSection = (
   keys: readonly string[],

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -420,7 +420,10 @@ export const mobileDevices = pgTable("mobile_devices", {
 
 export const pushNotifications = pgTable("push_notifications", {
   id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
-  userId: varchar("user_id").notNull().references(() => users.id),
+  userId: integer("user_id")
+    .$type<number>()
+    .notNull()
+    .references(() => users.id),
   title: varchar("title").notNull(),
   body: text("body").notNull(),
   type: varchar("type").notNull().default('system'),
@@ -434,8 +437,8 @@ export const pushNotifications = pgTable("push_notifications", {
 });
 
 export const notificationPreferences = pgTable("notification_preferences", {
-  userId: varchar("user_id")
-    .$type<string>()
+  userId: integer("user_id")
+    .$type<number>()
     .primaryKey()
     .references(() => users.id, { onDelete: 'cascade' }),
   email: jsonb("email").$type<Record<string, boolean>>().notNull().default({}),


### PR DESCRIPTION
## Summary
- ensure push notification and preference schemas use numeric user IDs
- normalize server-side notification flows to work with number IDs
- update notification routes to surface invalid session IDs

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f51fce6df88320a95ae5e1eb7426d7