### PR TITLE
Revamp light theme with corporate palette

### DIFF
--- a/client/src/styles/replit-theme.css
+++ b/client/src/styles/replit-theme.css
@@ -3,103 +3,99 @@
   color-scheme: light;
 
   /* Design tokens used by the Tailwind theme */
-  --background: 210 40% 98%;
+  --background: 214 33% 97%;
   --foreground: 222.2 47.4% 11.2%;
   --card: 0 0% 100%;
   --card-foreground: 222.2 47.4% 11.2%;
   --popover: 0 0% 100%;
   --popover-foreground: 222.2 47.4% 11.2%;
-  --primary: 210 100% 47.5%;
+  --primary: 214 92% 40%;
   --primary-foreground: 0 0% 100%;
-  --secondary: 210 40% 96.1%;
+  --secondary: 215 30% 93%;
   --secondary-foreground: 222.2 47.4% 11.2%;
-  --muted: 210 40% 96.1%;
-  --muted-foreground: 215.4 16.3% 46.9%;
-  --accent: 214.3 31.8% 91.4%;
-  --accent-foreground: 222.2 47.4% 11.2%;
+  --muted: 215 30% 93%;
+  --muted-foreground: 215.4 16.3% 36.9%;
+  --accent: 213 100% 93%;
+  --accent-foreground: 221 47% 15%;
   --destructive: 0 72.2% 50.6%;
   --destructive-foreground: 210 40% 98%;
-  --border: 214.3 31.8% 91.4%;
-  --input: 214.3 31.8% 91.4%;
-  --ring: 210 100% 47.5%;
-  --chart-1: 210 100% 47.5%;
+  --border: 218 27% 88%;
+  --input: 218 27% 88%;
+  --ring: 214 92% 40%;
+  --chart-1: 214 92% 40%;
   --chart-2: 160.1 84.1% 39.4%;
   --chart-3: 24.6 95% 53.1%;
   --chart-4: 258.3 89.5% 66.3%;
   --chart-5: 0 84.2% 60.2%;
-  --sidebar-background: 210 40% 98%;
+  --sidebar-background: 214 35% 96%;
   --sidebar-foreground: 222.2 47.4% 11.2%;
-  --sidebar-primary: 210 100% 47.5%;
+  --sidebar-primary: 214 92% 40%;
   --sidebar-primary-foreground: 0 0% 100%;
-  --sidebar-accent: 214.3 31.8% 91.4%;
+  --sidebar-accent: 214 45% 92%;
   --sidebar-accent-foreground: 222.2 47.4% 11.2%;
-  --sidebar-border: 210 17.5% 84.3%;
-  --sidebar-ring: 210 100% 47.5%;
-  --background-rgb: 248, 250, 252;
+  --sidebar-border: 215 26% 85%;
+  --sidebar-ring: 214 92% 40%;
+  --background-rgb: 244, 246, 252;
 
   /* E-Code corporate light palette */
-  --ecode-background: #f5f7fb;
+  --ecode-background: #f4f6fb;
   --ecode-surface: #ffffff;
-  --ecode-surface-secondary: #eef2f8;
-  --ecode-border: #d3dbea;
-  --ecode-border-strong: #c1ccde;
+  --ecode-surface-secondary: #edf1f8;
+  --ecode-border: #d4dae7;
+  --ecode-border-strong: #b6c1d8;
   --ecode-text: #0f172a;
-  --ecode-text-secondary: #475569;
-  --ecode-text-muted: #64748b;
-  --ecode-text: #0f172a;
-  --ecode-text-secondary: #475569;
-  --ecode-accent: #0b63f6;
-  --ecode-accent-hover: #084ebd;
-  --ecode-danger: #d92d20;
+  --ecode-text-secondary: #1f2937;
+  --ecode-text-muted: #4b5563;
+  --ecode-accent: #0b53d7;
+  --ecode-accent-hover: #073e9f;
+  --ecode-danger: #c0352b;
   --ecode-warning: #b54708;
   --ecode-info: #2563eb;
 
-  --ecode-surface-hover: #e7edf9;
-  --ecode-surface-elevated: rgba(255, 255, 255, 0.94);
+  --ecode-surface-hover: #e8edf7;
+  --ecode-surface-elevated: rgba(255, 255, 255, 0.96);
 
-  --ecode-green: #15803d;
-  --ecode-blue: #0b63f6;
-  --ecode-purple: #7c3aed;
-  --ecode-orange: #f97316;
-  --ecode-red: #e11d48;
+  --ecode-green: #1b7f4d;
+  --ecode-blue: #0b53d7;
+  --ecode-purple: #5f3fdc;
+  --ecode-orange: #ef7c3c;
+  --ecode-red: #d12c4d;
 
-  --ecode-sidebar-bg: #f0f4fb;
-  --ecode-sidebar-hover: #e3e9f5;
-  --ecode-sidebar-active: #0b63f6;
-  --ecode-sidebar-border: #d3dbea;
+  --ecode-sidebar-bg: #eef2f9;
+  --ecode-sidebar-hover: #e2e8f6;
+  --ecode-sidebar-active: #0b53d7;
+  --ecode-sidebar-border: #c5cfdf;
 
   --ecode-editor-bg: #ffffff;
-  --ecode-editor-gutter: #f1f5fb;
-  --ecode-editor-selection: #cfe0fb;
-  --ecode-editor-line-highlight: #f3f7ff;
+  --ecode-editor-gutter: #eef2f8;
+  --ecode-editor-selection: #d3e0fb;
+  --ecode-editor-line-highlight: #eef3ff;
 
   --ecode-terminal-bg: #0f172a;
   --ecode-terminal-text: #e2e8f0;
-  --ecode-terminal-cursor: #0b63f6;
+  --ecode-terminal-cursor: #0b53d7;
 
-  --ecode-button-primary: #0b63f6;
-  --ecode-button-primary-hover: #084ebd;
-  --ecode-button-secondary: #e3e9f5;
-  --ecode-button-secondary-hover: #cbd5e1;
+  --ecode-button-primary: #0b53d7;
+  --ecode-button-primary-hover: #073e9f;
+  --ecode-button-secondary: #e3e8f4;
+  --ecode-button-secondary-hover: #cdd5e6;
 
-  --ecode-shadow-sm: 0 10px 30px -15px rgba(15, 23, 42, 0.25);
-  --ecode-shadow-md: 0 20px 45px -20px rgba(15, 23, 42, 0.3);
-  --ecode-shadow-lg: 0 35px 65px -30px rgba(15, 23, 42, 0.35);
+  --ecode-shadow-sm: 0 12px 28px -18px rgba(15, 23, 42, 0.35);
+  --ecode-shadow-md: 0 24px 46px -22px rgba(15, 23, 42, 0.32);
+  --ecode-shadow-lg: 0 40px 68px -28px rgba(15, 23, 42, 0.3);
 
   /* Marketing surfaces */
-  --marketing-surface-bg: linear-gradient(180deg, #f8fbff 0%, #eef3ff 100%);
+  --marketing-surface-bg: linear-gradient(180deg, #f8fbff 0%, #eef2fb 100%);
   --marketing-surface-text: #0f172a;
-  --marketing-backdrop: radial-gradient(circle at top left, rgba(59, 130, 246, 0.18), transparent 55%),
-    radial-gradient(circle at top right, rgba(15, 118, 110, 0.12), transparent 50%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(226, 232, 240, 0.94));
-  --marketing-gradient: radial-gradient(circle at 20% 20%, rgba(14, 165, 233, 0.12), transparent 55%),
-    radial-gradient(circle at 80% 15%, rgba(59, 130, 246, 0.14), transparent 50%),
-    radial-gradient(circle at 50% 75%, rgba(99, 102, 241, 0.12), transparent 45%);
-  --marketing-grid-line: rgba(148, 163, 184, 0.12);
-  --marketing-divider: linear-gradient(90deg, rgba(59, 130, 246, 0), rgba(59, 130, 246, 0.2), rgba(59, 130, 246, 0));
-  --marketing-glass-bg: rgba(255, 255, 255, 0.65);
-  --marketing-glass-border: rgba(148, 163, 184, 0.35);
-  --marketing-glass-shadow: 0 24px 48px -32px rgba(15, 23, 42, 0.25);
+  --marketing-backdrop: radial-gradient(circle at 12% 18%, rgba(11, 83, 215, 0.18), transparent 58%),
+    radial-gradient(circle at 82% 12%, rgba(37, 99, 235, 0.16), transparent 54%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(229, 234, 244, 0.92));
+  --marketing-gradient: linear-gradient(135deg, rgba(11, 83, 215, 0.08) 0%, rgba(29, 78, 216, 0.16) 45%, rgba(30, 64, 175, 0.1) 100%);
+  --marketing-grid-line: rgba(148, 163, 184, 0.18);
+  --marketing-divider: linear-gradient(90deg, rgba(11, 83, 215, 0), rgba(11, 83, 215, 0.35), rgba(11, 83, 215, 0));
+  --marketing-glass-bg: rgba(255, 255, 255, 0.75);
+  --marketing-glass-border: rgba(164, 174, 196, 0.45);
+  --marketing-glass-shadow: 0 30px 60px -32px rgba(15, 23, 42, 0.3);
 
   /* Spacing - Replit system */
   --ecode-space-1: 4px;


### PR DESCRIPTION
## Summary
- overhaul the light theme token palette with a high-contrast corporate look
- refresh marketing surface gradients, shadows, and accent tokens for a polished Fortune 500 aesthetic
- keep the dark theme values unchanged while aligning shared brand colors

## Testing
- not run (css-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f520d6ff68832095e78e93f8cdda8f