### PR TITLE
Fix workspace projectId resolution for slug routes

### DIFF
--- a/client/src/pages/ProjectPage.tsx
+++ b/client/src/pages/ProjectPage.tsx
@@ -128,7 +128,6 @@ const ProjectPage = () => {
   // Determine if we're using ID or slug route
   const isSlugRoute = !!slugMatch && !!slugUsername && !!slugProjectName;
   const projectIdParam = paramsId?.id || paramsLegacyId?.id || null;
-  const projectId = projectIdParam ? parseInt(projectIdParam, 10) : null;
   // The projectSlug should just be the slug itself, not the full path
   const projectSlug = isSlugRoute ? slugProjectName : null;
   const projectUsername = isSlugRoute ? slugUsername : null;
@@ -225,14 +224,14 @@ const ProjectPage = () => {
     isLoading: projectLoading, 
     error: projectError 
   } = useQuery<Project>({
-    queryKey: projectSlug ? ['project-by-slug', projectUsername, projectSlug] : ['project-by-id', projectId],
+    queryKey: projectSlug ? ['project-by-slug', projectUsername, projectSlug] : ['project-by-id', projectIdParam],
     queryFn: async () => {
-      if (!projectId && !projectSlug) return Promise.reject(new Error('No project identifier provided'));
-      
+      if (!projectIdParam && !projectSlug) return Promise.reject(new Error('No project identifier provided'));
+
       // Note: projectname in the route is actually the project slug
       const url = projectSlug && projectUsername
         ? `/api/users/${projectUsername}/projects/${projectSlug}`
-        : `/api/projects/${projectId}`;
+        : `/api/projects/${projectIdParam}`;
       
       console.log('Fetching project from:', url);
       
@@ -252,7 +251,7 @@ const ProjectPage = () => {
       console.log('Project loaded:', projectData);
       return projectData;
     },
-    enabled: !!projectId || !!projectSlug,
+    enabled: !!projectIdParam || !!projectSlug,
     retry: (failureCount, error) => {
       // Don't retry on authentication errors or not found errors
       if (error.message.includes('log in') || error.message.includes('not found')) {
@@ -262,17 +261,19 @@ const ProjectPage = () => {
     }
   });
 
+  const projectId = project?.id ?? projectIdParam ?? null;
+
   // Query for fetching project files
-  const { 
-    data: files, 
-    isLoading: filesLoading, 
-    error: filesError 
+  const {
+    data: files,
+    isLoading: filesLoading,
+    error: filesError
   } = useQuery<File[]>({
-    queryKey: ['/api/projects', project?.id, 'files'],
+    queryKey: ['/api/projects', projectId, 'files'],
     queryFn: async () => {
-      const actualProjectId = project?.id || projectId;
+      const actualProjectId = projectId;
       if (!actualProjectId) return Promise.reject(new Error('No project ID provided'));
-      
+
       const res = await apiRequest('GET', `/api/projects/${actualProjectId}/files`);
       if (!res.ok) {
         const error = await res.text();
@@ -283,7 +284,7 @@ const ProjectPage = () => {
       }
       return res.json();
     },
-    enabled: !!(project?.id || projectId),
+    enabled: !!projectId,
     retry: (failureCount, error) => {
       // Don't retry on authentication errors
       if (error.message.includes('log in')) {
@@ -301,7 +302,7 @@ const ProjectPage = () => {
     const prompt = searchParams.get('prompt');
     
     // Use the project ID from the loaded project data
-    const effectiveProjectId = project?.id || projectId;
+    const effectiveProjectId = project?.id ?? projectId;
     
     if (isAgentMode && prompt && effectiveProjectId) {
       // Show the main agent interface with the prompt
@@ -345,7 +346,7 @@ const ProjectPage = () => {
       });
       
       // Refresh file list to get updated timestamps
-      const actualProjectId = project?.id || projectId;
+      const actualProjectId = project?.id ?? projectId;
       queryClient.invalidateQueries({ queryKey: ['/api/projects', actualProjectId, 'files'] });
     },
     onError: (error: Error) => {
@@ -361,7 +362,7 @@ const ProjectPage = () => {
   // Mutation for creating a new file
   const createFileMutation = useMutation({
     mutationFn: async ({ parentId, name, isFolder }: { parentId: number | null, name: string, isFolder: boolean }) => {
-      const actualProjectId = project?.id || projectId;
+      const actualProjectId = project?.id ?? projectId;
       if (!actualProjectId) return Promise.reject(new Error('No project ID provided'));
       
       const newFile = {
@@ -379,7 +380,7 @@ const ProjectPage = () => {
       return res.json();
     },
     onSuccess: () => {
-      const actualProjectId = project?.id || projectId;
+      const actualProjectId = project?.id ?? projectId;
       queryClient.invalidateQueries({ queryKey: ['/api/projects', actualProjectId, 'files'] });
       toast({
         title: "File created",
@@ -410,7 +411,7 @@ const ProjectPage = () => {
         setSelectedFile(null);
       }
       
-      const actualProjectId = project?.id || projectId;
+      const actualProjectId = project?.id ?? projectId;
       queryClient.invalidateQueries({ queryKey: ['/api/projects', actualProjectId, 'files'] });
       toast({
         title: "File deleted",
@@ -436,7 +437,7 @@ const ProjectPage = () => {
       return res.json();
     },
     onSuccess: () => {
-      const actualProjectId = project?.id || projectId;
+      const actualProjectId = project?.id ?? projectId;
       queryClient.invalidateQueries({ queryKey: ['/api/projects', actualProjectId, 'files'] });
       toast({
         title: "File renamed",
@@ -455,7 +456,7 @@ const ProjectPage = () => {
   // Mutation for starting the project
   const startProjectMutation = useMutation({
     mutationFn: async () => {
-      const actualProjectId = project?.id || projectId;
+      const actualProjectId = project?.id ?? projectId;
       if (!actualProjectId) return Promise.reject(new Error('No project ID provided'));
       
       const res = await apiRequest('POST', `/api/runtime/${actualProjectId}/start`);
@@ -483,7 +484,7 @@ const ProjectPage = () => {
   // Mutation for stopping the project
   const stopProjectMutation = useMutation({
     mutationFn: async () => {
-      const actualProjectId = project?.id || projectId;
+      const actualProjectId = project?.id ?? projectId;
       if (!actualProjectId) return Promise.reject(new Error('No project ID provided'));
       
       const res = await apiRequest('POST', `/api/runtime/${actualProjectId}/stop`);
@@ -613,7 +614,7 @@ const ProjectPage = () => {
 
   // Check project status on load
   useEffect(() => {
-    const actualProjectId = project?.id || projectId;
+    const actualProjectId = project?.id ?? projectId;
     if (!actualProjectId) return;
     
     const checkStatus = async () => {
@@ -676,7 +677,7 @@ const ProjectPage = () => {
               <Button 
                 variant="outline" 
                 onClick={() => {
-                  const actualProjectId = project?.id || projectId;
+                  const actualProjectId = project?.id ?? projectId;
                   queryClient.invalidateQueries({ queryKey: projectSlug ? ['project-by-slug', projectUsername, projectSlug] : ['project-by-id', actualProjectId] });
                   queryClient.invalidateQueries({ queryKey: ['/api/projects', actualProjectId, 'files'] });
                 }}
@@ -960,12 +961,12 @@ const ProjectPage = () => {
       {/* Main Content Area */}
       <div className="flex-1 flex overflow-hidden">
         {/* Show Main Agent Interface as Principal when active (like Replit) */}
-        {showMainAgent && (project?.id || projectId) ? (
+        {showMainAgent && (project?.id ?? projectId) ? (
           <div className="flex-1 flex">
             {/* Agent Interface takes center stage */}
             <div className="flex-1 flex flex-col">
-              <MainAgentInterface 
-                projectId={project?.id || projectId}
+              <MainAgentInterface
+                projectId={project?.id ?? projectId}
                 initialPrompt={agentPrompt}
                 onMinimize={() => setShowMainAgent(false)}
                 className="h-full"
@@ -974,7 +975,7 @@ const ProjectPage = () => {
             
             {/* Files sidebar on the right when agent is active */}
             <div className="w-64 border-l overflow-auto">
-              <ReplitSidebar projectId={projectId} />
+              <ReplitSidebar projectId={(project?.id ?? projectId) || undefined} />
             </div>
           </div>
         ) : (
@@ -982,7 +983,7 @@ const ProjectPage = () => {
             {/* Traditional layout when agent is not active */}
             {/* Left Sidebar with Files, Agent, Tools, etc. */}
             <div className="w-64 overflow-auto border-r">
-              <ReplitSidebar projectId={projectId || 0} />
+              <ReplitSidebar projectId={(project?.id ?? projectId) || undefined} />
             </div>
             
             {/* Middle Section: Editor and Terminal */}
@@ -1265,8 +1266,8 @@ const ProjectPage = () => {
               <FileUploadDropzone 
                 projectId={projectId} 
                 onUploadComplete={() => {
-                  const actualProjectId = project?.id || projectId;
-      queryClient.invalidateQueries({ queryKey: ['/api/projects', actualProjectId, 'files'] });
+                  const actualProjectId = project?.id ?? projectId;
+                  queryClient.invalidateQueries({ queryKey: ['/api/projects', actualProjectId, 'files'] });
                 }}
               />
             </div>


### PR DESCRIPTION
## Summary
- resolve the active project id from loaded project data so slug routes expose an id to the workspace
- update the files query to use the resolved id, preventing null identifiers from blocking file loads
- keep downstream panels and utilities working by relying on the resolved project id value

## Testing
- npm test *(fails: `ipSecurity blocks blacklisted addresses` due to `nextCalled` not defined in test setup)*

------
https://chatgpt.com/codex/tasks/task_e_68f51eeb9b548320ab43e359602c7b9a