### PR TITLE
Address Codex review feedback for notification user IDs

### DIFF
--- a/server/routes/notifications.ts
+++ b/server/routes/notifications.ts
@@ -33,7 +33,7 @@ const normalizeNotificationResponse = (notification: any) => {
   };
 };
 
-const getUserIdOrThrow = (req: any, res: any): number | null => {
+const getUserIdOrThrow = (req: any, res: any): string | null => {
   const rawUserId = req.user?.id;
   if (rawUserId === undefined || rawUserId === null) {
     res.status(401).json({ message: 'Not authenticated' });
@@ -42,19 +42,21 @@ const getUserIdOrThrow = (req: any, res: any): number | null => {
 
   if (typeof rawUserId === 'number') {
     if (Number.isInteger(rawUserId)) {
-      return rawUserId;
+      return String(rawUserId);
     }
     res.status(400).json({ message: 'Invalid user session' });
     return null;
   }
 
-  const normalized = Number.parseInt(String(rawUserId).trim(), 10);
-  if (!Number.isInteger(normalized)) {
-    res.status(400).json({ message: 'Invalid user session' });
-    return null;
+  if (typeof rawUserId === 'string') {
+    const trimmed = rawUserId.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
   }
 
-  return normalized;
+  res.status(400).json({ message: 'Invalid user session' });
+  return null;
 };
 
 const getPreferencesHandler = async (req: any, res: any) => {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -162,25 +162,20 @@ const DEFAULT_NOTIFICATION_PREFERENCES: {
   frequency: 'instant',
 };
 
-const normalizeUserId = (userId: string | number): number => {
+const normalizeUserId = (userId: string | number): string => {
   if (typeof userId === 'number') {
     if (Number.isInteger(userId)) {
-      return userId;
+      return String(userId);
     }
     throw new TypeError('User ID must be an integer');
   }
 
   const trimmed = userId.trim();
-  if (!/^-?\d+$/.test(trimmed)) {
+  if (trimmed.length === 0) {
     throw new TypeError('Invalid user ID format');
   }
 
-  const parsed = Number.parseInt(trimmed, 10);
-  if (!Number.isFinite(parsed)) {
-    throw new TypeError('Invalid user ID value');
-  }
-
-  return parsed;
+  return trimmed;
 };
 
 const normalizePreferenceSection = (

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -420,8 +420,7 @@ export const mobileDevices = pgTable("mobile_devices", {
 
 export const pushNotifications = pgTable("push_notifications", {
   id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
-  userId: integer("user_id")
-    .$type<number>()
+  userId: varchar("user_id")
     .notNull()
     .references(() => users.id),
   title: varchar("title").notNull(),
@@ -437,8 +436,7 @@ export const pushNotifications = pgTable("push_notifications", {
 });
 
 export const notificationPreferences = pgTable("notification_preferences", {
-  userId: integer("user_id")
-    .$type<number>()
+  userId: varchar("user_id")
     .primaryKey()
     .references(() => users.id, { onDelete: 'cascade' }),
   email: jsonb("email").$type<Record<string, boolean>>().notNull().default({}),


### PR DESCRIPTION
## Summary
- restore the notification schema foreign keys to use string user IDs compatible with users.id UUIDs
- update notification storage utilities to normalize user identifiers as trimmed strings
- ensure notification routes validate session user IDs without numeric coercion

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f526b10dfc8320921f0a81e02f9b3c