### PR TITLE
Handle integer user IDs in notification preference migration

### DIFF
--- a/migrations/0004_notification_preferences_user_id_to_varchar.sql
+++ b/migrations/0004_notification_preferences_user_id_to_varchar.sql
@@ -1,17 +1,27 @@
--- Convert notification_preferences.user_id to varchar to match users.id
+-- Convert notification_preferences.user_id to varchar when users.id is also varchar
 DO $$
 DECLARE
   constraint_exists BOOLEAN;
+  users_id_type TEXT;
 BEGIN
-  -- Only run if the column exists and isn't already character varying
-  IF EXISTS (
-    SELECT 1
-    FROM information_schema.columns
-    WHERE table_schema = 'public'
-      AND table_name = 'notification_preferences'
-      AND column_name = 'user_id'
-      AND data_type <> 'character varying'
-  ) THEN
+  SELECT data_type INTO users_id_type
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'users'
+    AND column_name = 'id';
+
+  IF users_id_type IS NULL THEN
+    RAISE NOTICE 'Skipping conversion of notification_preferences.user_id because users.id column was not found';
+  ELSIF users_id_type = 'character varying' THEN
+    -- Only run if the column exists and isn't already character varying
+    IF EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'notification_preferences'
+        AND column_name = 'user_id'
+        AND data_type <> 'character varying'
+    ) THEN
     -- Drop foreign key constraint if it exists to allow type change
     SELECT EXISTS (
       SELECT 1
@@ -36,5 +46,8 @@ BEGIN
       ADD CONSTRAINT "notification_preferences_user_id_users_id_fk"
         FOREIGN KEY ("user_id") REFERENCES "users" ("id")
         ON DELETE cascade ON UPDATE no action;
+    END IF;
+  ELSE
+    RAISE NOTICE 'Skipping conversion of notification_preferences.user_id because users.id is of type %', users_id_type;
   END IF;
 END $$;


### PR DESCRIPTION
## Summary
- guard the notification preference migration so it only converts the column when `users.id` is already `varchar`
- add notices when the migration skips conversion because the referenced `users.id` column is missing or incompatible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f526b2049c83209cca809343f8a128