### PR TITLE
Prevent unauthenticated calls on project views

### DIFF
--- a/client/src/pages/Editor.tsx
+++ b/client/src/pages/Editor.tsx
@@ -12,10 +12,13 @@ import Preview from "@/components/Preview";
 import BottomPanel from "@/components/BottomPanel";
 import TopNavbar from "@/components/TopNavbar";
 import { ContextMenu } from "@/components/ContextMenu";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/use-auth";
 
 export default function Editor() {
   const { id } = useParams();
   const { toast } = useToast();
+  const { user, isLoading: authLoading } = useAuth();
   const [openFiles, setOpenFiles] = useState<File[]>([]);
   const [activeFileId, setActiveFileId] = useState<number | null>(null);
   const [contextMenu, setContextMenu] = useState<{
@@ -34,12 +37,38 @@ export default function Editor() {
   // Get project data
   const { data: project, isLoading: isProjectLoading } = useQuery<Project>({
     queryKey: [`/api/projects/${id}`],
+    enabled: !!id && !!user,
   });
 
   // Get project files
   const { data: files = [], isLoading: isFilesLoading } = useQuery<File[]>({
     queryKey: [`/api/files/${id}`],
+    enabled: !!id && !!user,
   });
+
+  if (authLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p className="text-muted-foreground">Checking your session...</p>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center space-y-4">
+          <h2 className="text-2xl font-semibold">Sign in required</h2>
+          <p className="text-muted-foreground">
+            Log in to access your workspace and edit files.
+          </p>
+          <Button onClick={() => (window.location.href = '/login')}>
+            Go to login
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   // Save file content mutation
   const saveFileMutation = useMutation({

--- a/client/src/pages/ProjectsPage.tsx
+++ b/client/src/pages/ProjectsPage.tsx
@@ -120,7 +120,7 @@ interface ProjectWithOwner extends Project {
 const ProjectsPage = () => {
   const [location, setLocation] = useLocation();
   const { toast } = useToast();
-  const { user } = useAuth();
+  const { user, isLoading: authLoading } = useAuth();
   const [newProjectOpen, setNewProjectOpen] = useState(false);
   const [deleteProjectId, setDeleteProjectId] = useState<number | null>(null);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
@@ -162,18 +162,20 @@ const ProjectsPage = () => {
       const teamsData = await res.json();
       return [
         { id: 'personal', name: 'Personal', icon: User },
-        ...teamsData.map((team: any) => ({ 
-          id: team.id, 
-          name: team.name, 
-          icon: Users 
+        ...teamsData.map((team: any) => ({
+          id: team.id,
+          name: team.name,
+          icon: Users
         }))
       ];
-    }
+    },
+    enabled: !!user
   });
 
   // Fetch folders
   const { data: folders = [] } = useQuery<Array<{ id: string; name: string; count: number }>>({
     queryKey: ['/api/folders'],
+    enabled: !!user
   });
 
   // Fetch pinned projects
@@ -184,7 +186,8 @@ const ProjectsPage = () => {
       if (!res.ok) return [];
       const projects = await res.json();
       return projects.map((p: any) => p.id);
-    }
+    },
+    enabled: !!user
   });
 
   // Query for fetching projects
@@ -196,8 +199,37 @@ const ProjectsPage = () => {
         throw new Error('Failed to fetch projects');
       }
       return res.json();
-    }
+    },
+    enabled: !!user
   });
+
+  if (authLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <ECodeLoading size="lg" text="Checking your session..." />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <Card className="max-w-lg text-center">
+          <CardHeader>
+            <CardTitle>Sign in to view your projects</CardTitle>
+            <CardDescription>
+              You need an active session to access workspaces and project data. Please log in to continue.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button onClick={() => (window.location.href = '/login')} className="w-full">
+              Go to login
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
 
   // Filter and sort projects
   const filteredProjects = useMemo(() => {


### PR DESCRIPTION
## Summary
- block project list queries when no session and show a login prompt instead of a blank page
- guard editor workspace data fetching behind authenticated checks with a friendly login call-to-action

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5348e03348320b3c6db9085d481e6