### PR TITLE
Ensure DATABASE_URL is required for session store initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ cp .env.production.example .env
 #   ANTHROPIC_API_KEY=your-anthropic-key
 #   GOOGLE_GENAI_API_KEY=optional-google-models
 
+# ❗️The application requires a reachable PostgreSQL instance available at `DATABASE_URL`.
+# It is used both by Drizzle for core data and by the `connect-pg-simple` session store.
+# If the database is missing or unreachable, authentication and project creation flows will fail.
+
 # Provision the database schema
 npm run db:push
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -4033,6 +4033,12 @@ export const storage = new DatabaseStorage();
 // Session store with pg pool
 import { Pool } from 'pg';
 
+if (!process.env.DATABASE_URL) {
+  throw new Error(
+    "DATABASE_URL must be set before initializing the session store. The application requires an accessible PostgreSQL instance for both data persistence and session management."
+  );
+}
+
 // Create a native pg pool for session store
 const pgPool = new Pool({
   connectionString: process.env.DATABASE_URL,


### PR DESCRIPTION
## Summary
- fail fast when the session store is initialized without a configured DATABASE_URL so PostgreSQL must be available
- document in the README that the app depends on a reachable PostgreSQL instance for authentication and project creation

## Testing
- not run (documentation-only and configuration guard change)


------
https://chatgpt.com/codex/tasks/task_e_68f534bd04b083208076f576409cf23f