### PR TITLE
Document automatic seeding accounts in getting started guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,7 +55,9 @@ The project uses [Drizzle ORM](https://orm.drizzle.team/) to manage schema migra
 npm run db:push
 ```
 
-This command connects to the database defined in `DATABASE_URL`, creates tables, and seeds a QA-friendly dataset including the `testuser` account.
+This command connects to the database defined in `DATABASE_URL`, creates tables, and readies the schema for the automatic seed that runs during development startup.
+
+> **Note:** The seed script only runs when the tables already exist. Always execute `npm run db:push` before launching the dev server.
 
 ## 4. Launch the Development Stack
 
@@ -65,7 +67,9 @@ npm run dev
 
 - The Express API and Vite dev server share port **5000**.
 - The initial build may take 2–3 minutes as Monaco Editor, Radix UI, and AI SDK packages compile.
-- Navigate to `http://localhost:5000` and log in with `testuser` / `testpass123`.
+- Navigate to `http://localhost:5000` and log in with either of the pre-seeded accounts:
+  - `admin` / `demo` (administrator role)
+  - `testuser` / `testpass123` (standard QA account)
 
 ### Verifying Key Features
 


### PR DESCRIPTION
## Summary
- clarify that `npm run db:push` prepares the schema before the automatic seed runs
- document the prerequisite to run migrations before starting the dev server
- note both admin and test accounts that are created by the seed script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5354b38d48320a634da182d196f6e