### PR TITLE
Document AI provider key requirement for agent actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ cp .env.production.example .env
 #   ANTHROPIC_API_KEY=your-anthropic-key
 #   GOOGLE_GENAI_API_KEY=optional-google-models
 
+# ⚠️ If none of the AI provider keys are supplied on the server process, prompts sent from
+# the workspace UI will fail silently. The frontend suppresses provider errors to avoid
+# leaking implementation details, so always double-check that at least one of
+# `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `GOOGLE_GENAI_API_KEY` is configured before
+# testing agent actions.
+
 # Provision the database schema
 npm run db:push
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,6 +47,10 @@ Minimum variables to review:
 
 > **Security Note:** Avoid committing the `.env` file. Store production secrets in the organization’s secret manager (e.g., GCP Secret Manager or HashiCorp Vault).
 
+> **AI Agent Reminder:** Without at least one of the AI provider keys set on the server (OpenAI, Anthropic, or Google GenAI),
+> requests made from the AI sidebar will appear to do nothing. The UI intentionally suppresses raw provider errors, so double-check
+> the environment variables when agent interactions seem unresponsive.
+
 ## 3. Provision the Database
 
 The project uses [Drizzle ORM](https://orm.drizzle.team/) to manage schema migrations.


### PR DESCRIPTION
## Summary
- add README guidance describing the need for AI provider API keys when testing agent prompts
- update the getting started guide with a reminder that missing provider keys cause seemingly silent AI failures

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f5356cac7c8320847aedd140c9eca3