### PR TITLE
Ensure automatic migrations during database init

### DIFF
--- a/server/db-init.ts
+++ b/server/db-init.ts
@@ -1,8 +1,11 @@
 // @ts-nocheck
-import { db } from "./db";
+import { db, client } from "./db";
 import * as schema from "@shared/schema";
 import { scrypt, randomBytes } from "crypto";
 import { promisify } from "util";
+import { existsSync } from "fs";
+import { resolve } from "path";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
 
 const scryptAsync = promisify(scrypt);
 
@@ -11,6 +14,60 @@ async function hashPassword(password: string) {
   const salt = randomBytes(16).toString("hex");
   const buf = (await scryptAsync(password, salt, 64)) as Buffer;
   return `${buf.toString("hex")}.${salt}`;
+}
+
+let migrationsEnsured = false;
+
+async function ensureDatabaseMigrated(force = false) {
+  if (migrationsEnsured && !force) {
+    return;
+  }
+
+  const migrationsFolder = resolve(process.cwd(), "migrations");
+
+  if (!existsSync(migrationsFolder)) {
+    console.warn(
+      `Database migrations folder not found at ${migrationsFolder}. ` +
+      "Automatic migration skipped. Run `npm run db:push` to create the schema manually.",
+    );
+    migrationsEnsured = true;
+    return;
+  }
+
+  let isFreshDatabase = force;
+
+  if (!isFreshDatabase) {
+    try {
+      const [row] = await client`
+        select exists (
+          select 1
+          from information_schema.tables
+          where table_schema = 'public'
+            and table_name = 'users'
+        ) as "exists";
+      `;
+
+      isFreshDatabase = !row?.exists;
+    } catch (error) {
+      console.warn("Failed to inspect database schema, attempting automatic migration", error);
+      isFreshDatabase = true;
+    }
+  }
+
+  const statusMessage = isFreshDatabase
+    ? "Database schema is missing. Applying initial migrations..."
+    : "Ensuring database schema is up to date via migrations...";
+
+  console.log(statusMessage);
+
+  try {
+    await migrate(db, { migrationsFolder });
+    console.log("Database migrations applied successfully.");
+    migrationsEnsured = true;
+  } catch (migrationError) {
+    console.error("Automatic database migration failed:", migrationError);
+    throw migrationError;
+  }
 }
 
 // Initialize the database with default data
@@ -22,13 +79,15 @@ export async function initializeDatabase() {
   while (retries > 0) {
     try {
       console.log(`Initializing database... (attempt ${4 - retries})`);
-      
+
+      await ensureDatabaseMigrated();
+
       // Check if tables are created by checking if we have any users
       const users = await db.select().from(schema.users);
       if (users && users.length > 0) {
         console.log("Database already initialized. Skipping initialization.");
         return;
-    }
+      }
     
     // Create admin user
     const adminPassword = await hashPassword("admin");
@@ -148,8 +207,20 @@ document.addEventListener('DOMContentLoaded', function() {
     } catch (error) {
       lastError = error;
       console.error(`Database initialization attempt failed:`, error.message);
+
+      if (error?.code === '42P01' || /relation ".+" does not exist/.test(error?.message || "")) {
+        // Table is missing even after our initial migration attempt. Force rerun migrations.
+        try {
+          console.warn("Detected missing tables after initialization attempt. Retrying migrations...");
+          migrationsEnsured = false; // allow ensureDatabaseMigrated to run again
+          await ensureDatabaseMigrated(true);
+        } catch (migrationError) {
+          console.error("Forced migration retry failed:", migrationError.message);
+        }
+      }
+
       retries--;
-      
+
       if (retries > 0) {
         // Wait before retrying (exponential backoff)
         await new Promise(resolve => setTimeout(resolve, (4 - retries) * 1000));

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,7 +3,6 @@ import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 import { initializeDatabase } from "./db-init";
-import { migrate } from "drizzle-orm/postgres-js/migrator";
 import cors from "cors";
 import compressionMiddleware from "./middleware/compression";
 import { securityMiddleware, sanitizeInput, securityMonitoring, ipSecurity } from "./middleware/security";


### PR DESCRIPTION
## Summary
- automatically apply Drizzle migrations during startup to provision missing tables
- retry migrations when missing-table errors are detected and surface actionable logging when migrations cannot be found
- remove the unused migrator import from the server bootstrap file

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f5371fb8d883208cb51d182e5364aa