### PR TITLE
Ensure Replit run command stays on dev

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,4 +1,5 @@
 modules = ["nodejs-20", "web", "postgresql-16", "python-3.11"]
+# IMPORTANT: keep the run command on `npm run dev` so Express and Vite share port 5000 for the frontend preview.
 run = "npm run dev"
 hidden = [".config", ".git", "generated-icon.png", "node_modules", "dist"]
 


### PR DESCRIPTION
## Summary
- document in `.replit` that the Run button must invoke `npm run dev` so the Express API and Vite front-end share port 5000

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5374db7308320878f9710d55b0984