### PR TITLE
Fix newsletter confirmation handling

### DIFF
--- a/client/src/pages/NewsletterConfirm.tsx
+++ b/client/src/pages/NewsletterConfirm.tsx
@@ -13,32 +13,48 @@ export default function NewsletterConfirm() {
   const [message, setMessage] = useState('');
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const email = params.get('email');
-    const token = params.get('token');
+    const confirmSubscription = async () => {
+      const params = new URLSearchParams(window.location.search);
+      const email = params.get('email');
+      const token = params.get('token');
 
-    if (!email || !token) {
-      setStatus('error');
-      setMessage('Invalid confirmation link');
-      return;
-    }
+      if (!email || !token) {
+        setStatus('error');
+        setMessage('Invalid confirmation link');
+        return;
+      }
 
-    // Confirm the email
-    fetch(`/api/newsletter/confirm?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}`)
-      .then(res => res.json())
-      .then(data => {
-        if (data.success) {
+      try {
+        const response = await fetch(`/api/newsletter/confirm?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}&format=json`, {
+          headers: {
+            Accept: 'application/json',
+          },
+        });
+
+        let data = null;
+        try {
+          data = await response.json();
+        } catch (_) {
+          data = null;
+        }
+
+        if (response.ok && data?.success) {
           setStatus('success');
           setMessage(data.message || 'Email confirmed successfully!');
         } else {
+          const errorMessage = data?.message || 'Failed to confirm email';
           setStatus('error');
-          setMessage(data.message || 'Failed to confirm email');
+          setMessage(errorMessage);
         }
-      })
-      .catch(() => {
+      } catch (error) {
         setStatus('error');
         setMessage('Something went wrong. Please try again.');
-      });
+      }
+    };
+
+    setStatus('loading');
+    setMessage('');
+    confirmSubscription();
   }, []);
 
   return (

--- a/client/src/pages/NewsletterConfirmed.tsx
+++ b/client/src/pages/NewsletterConfirmed.tsx
@@ -10,6 +10,7 @@ export default function NewsletterConfirmed() {
   const [, setLocation] = useLocation();
   const searchParams = new URLSearchParams(window.location.search);
   const success = searchParams.get('success') === 'true';
+  const errorMessage = searchParams.get('error');
 
   useEffect(() => {
     // Show confetti animation on success
@@ -28,12 +29,12 @@ export default function NewsletterConfirmed() {
           <CardHeader className="text-center">
             <CardTitle className="text-2xl">Invalid Confirmation Link</CardTitle>
             <CardDescription>
-              This confirmation link is invalid or has expired.
+              {errorMessage || 'This confirmation link is invalid or has expired.'}
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <p className="text-sm text-muted-foreground text-center">
-              If you're having trouble, please try subscribing again or contact our support team.
+              {errorMessage || "If you're having trouble, please try subscribing again or contact our support team."}
             </p>
             <div className="flex flex-col gap-2">
               <Button onClick={() => setLocation('/')} className="w-full">

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -324,6 +324,35 @@ function extractNewsletterRequestContext(req: Request) {
   };
 }
 
+function shouldRespondWithJson(req: Request): boolean {
+  const formatParam = typeof req.query.format === 'string' ? req.query.format.toLowerCase() : null;
+  if (formatParam === 'json') {
+    return true;
+  }
+
+  if (formatParam === 'html') {
+    return false;
+  }
+
+  const secFetchMode = (req.headers['sec-fetch-mode'] as string | undefined)?.toLowerCase();
+  if (secFetchMode && secFetchMode !== 'navigate') {
+    return true;
+  }
+
+  const acceptHeader = req.headers.accept;
+  const accepts = Array.isArray(acceptHeader) ? acceptHeader.join(',') : (acceptHeader ?? '');
+  if (accepts.toLowerCase().includes('application/json')) {
+    return true;
+  }
+
+  const requestedWith = (req.headers['x-requested-with'] as string | undefined)?.toLowerCase();
+  if (requestedWith === 'xmlhttprequest') {
+    return true;
+  }
+
+  return false;
+}
+
 const NEWSLETTER_EMAIL_STYLES = `
   body {
     margin: 0;
@@ -15814,31 +15843,57 @@ Generate a comprehensive application based on the user's request. Include all ne
   });
   
   app.get('/api/newsletter/confirm', async (req, res) => {
+    const expectsJson = shouldRespondWithJson(req);
+
     try {
       const { email, token } = req.query;
-      
+
       if (!email || !token) {
-        return res.status(400).json({ message: 'Email and token are required' });
+        const message = 'Email and token are required';
+        if (expectsJson) {
+          return res.status(400).json({ success: false, message });
+        }
+
+        return res.redirect(`/newsletter-confirmed?success=false&error=${encodeURIComponent(message)}`);
       }
-      
+
+      const sanitizedEmail = email as string;
+      const sanitizedToken = token as string;
+
       const confirmed = await storage.confirmNewsletterSubscription(
-        email as string,
-        token as string
+        sanitizedEmail,
+        sanitizedToken
       );
-      
+
       if (confirmed) {
-        // Send confirmation success email
         const { sendNewsletterConfirmedEmail } = await import('./utils/gandi-email');
-        await sendNewsletterConfirmedEmail(email as string);
-        
-        // Redirect to success page
-        res.redirect('/newsletter-confirmed?success=true');
-      } else {
-        res.status(400).json({ message: 'Invalid confirmation link' });
+        const delivered = await sendNewsletterConfirmedEmail(sanitizedEmail);
+        if (!delivered) {
+          console.warn('Newsletter confirmation email delivery skipped or failed for', sanitizedEmail);
+        }
+
+        const message = 'Your newsletter subscription has been confirmed!';
+        if (expectsJson) {
+          return res.json({ success: true, message });
+        }
+
+        return res.redirect('/newsletter-confirmed?success=true');
       }
+
+      const message = 'Invalid confirmation link';
+      if (expectsJson) {
+        return res.status(400).json({ success: false, message });
+      }
+
+      return res.redirect(`/newsletter-confirmed?success=false&error=${encodeURIComponent(message)}`);
     } catch (error) {
       console.error('Newsletter confirmation error:', error);
-      res.status(500).json({ message: 'Failed to confirm email' });
+      const message = 'Failed to confirm email';
+      if (expectsJson) {
+        return res.status(500).json({ success: false, message });
+      }
+
+      return res.redirect(`/newsletter-confirmed?success=false&error=${encodeURIComponent(message)}`);
     }
   });
   

--- a/server/utils/gandi-email.ts
+++ b/server/utils/gandi-email.ts
@@ -10,6 +10,7 @@ const GANDI_SMTP_PASS = process.env.GANDI_SMTP_PASS || process.env.GANDI_PASSWOR
 const FROM_EMAIL = process.env.FROM_EMAIL || 'noreply@e-code.ai';
 const FROM_NAME = process.env.FROM_NAME || 'E-Code';
 const BASE_URL = process.env.BASE_URL || 'http://localhost:5000';
+const APP_BASE_URL = BASE_URL.replace(/\/$/, '');
 
 // Create reusable transporter
 let transporter: Transporter | null = null;
@@ -155,7 +156,7 @@ export async function sendGandiEmail(options: {
 
 // Newsletter welcome email
 export async function sendNewsletterWelcomeEmail(email: string, confirmationToken: string): Promise<boolean> {
-  const confirmUrl = `${BASE_URL}/api/newsletter/confirm?email=${encodeURIComponent(email)}&token=${confirmationToken}`;
+  const confirmUrl = `${APP_BASE_URL}/newsletter/confirm?email=${encodeURIComponent(email)}&token=${confirmationToken}`;
   
   const html = getEmailTemplate(`
     <div class="email-header">
@@ -227,7 +228,7 @@ export async function sendNewsletterConfirmedEmail(email: string): Promise<boole
       </ul>
       <p>In the meantime, why not:</p>
       <div style="text-align: center; margin: 30px 0;">
-        <a href="${BASE_URL}/projects" class="email-button">Start Creating</a>
+        <a href="${APP_BASE_URL}/projects" class="email-button">Start Creating</a>
       </div>
     </div>
     <div class="email-footer">
@@ -245,7 +246,7 @@ Here's what you can expect:
 - Monthly Digest: Best projects and creator spotlights
 - Special Announcements: New features and events
 
-Start creating at: ${BASE_URL}/projects
+Start creating at: ${APP_BASE_URL}/projects
 
 Best regards,
 The E-Code Team`;


### PR DESCRIPTION
## Summary
- add JSON negotiation helper so `/api/newsletter/confirm` can respond cleanly to both browser navigations and API calls
- update newsletter emails to direct subscribers to the confirmation UI while reusing a normalized app base URL
- refresh the confirmation pages to request JSON responses from the API and display detailed error messaging when links are invalid

## Testing
- npm test *(fails: TransformError in test runner)*

------
https://chatgpt.com/codex/tasks/task_e_68f602300760832091bc54c497e7840b