### PR TITLE
Improve community post pagination and schema backfill

### DIFF
--- a/client/src/components/CommunityFeatures.tsx
+++ b/client/src/components/CommunityFeatures.tsx
@@ -109,8 +109,22 @@ export function CommunityFeatures() {
 
   // Fetch community data
   const { data: postsData, isLoading: postsLoading } = useQuery({
-    queryKey: ['/api/community/posts', { category: selectedCategory, tag: selectedTag, search: searchQuery }],
-    staleTime: 30000
+    queryKey: ['/api/community/posts', { category: selectedCategory, tag: selectedTag, search: searchQuery, pageSize: 6 }],
+    staleTime: 30000,
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (selectedCategory !== 'all') params.set('category', selectedCategory);
+      if (selectedTag) params.set('tag', selectedTag);
+      if (searchQuery) params.set('search', searchQuery);
+      params.set('pageSize', '6');
+      const res = await fetch(`/api/community/posts?${params.toString()}`, {
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        throw new Error('Failed to fetch community posts');
+      }
+      return res.json();
+    }
   });
 
   const { data: showcasesData, isLoading: showcasesLoading } = useQuery({

--- a/client/src/pages/Community.tsx
+++ b/client/src/pages/Community.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import React, { useMemo, useState } from 'react';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation, useInfiniteQuery } from '@tanstack/react-query';
 import { apiRequest, queryClient } from '@/lib/queryClient';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -49,6 +49,17 @@ interface CommunityPost {
   createdAt: string;
   projectUrl?: string;
   imageUrl?: string;
+}
+
+interface CommunityPostsResponse {
+  posts: CommunityPost[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    total: number;
+    totalPages: number;
+    hasMore: boolean;
+  };
 }
 
 interface Challenge {
@@ -180,18 +191,37 @@ export default function Community() {
     queryKey: ['/api/community/categories']
   });
 
-  // Build query string for posts
-  const queryParams = new URLSearchParams();
-  if (activeCategory !== 'all') queryParams.set('category', activeCategory);
-  if (searchQuery) queryParams.set('search', searchQuery);
-  const queryString = queryParams.toString();
+  const postsQueryKey = ['/api/community/posts', { category: activeCategory, search: searchQuery }];
 
-  // Fetch community posts
-  const { data: posts = [], isLoading: postsLoading } = useQuery<CommunityPost[]>({
-    queryKey: queryString 
-      ? [`/api/community/posts?${queryString}`]
-      : ['/api/community/posts']
+  const {
+    data: postsPages,
+    isLoading: postsInitialLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery<CommunityPostsResponse>({
+    queryKey: postsQueryKey,
+    initialPageParam: 1,
+    queryFn: async ({ pageParam = 1 }) => {
+      const params = new URLSearchParams();
+      if (activeCategory !== 'all') params.set('category', activeCategory);
+      if (searchQuery) params.set('search', searchQuery);
+      params.set('page', pageParam.toString());
+      params.set('pageSize', '20');
+      const res = await fetch(`/api/community/posts?${params.toString()}`, {
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to fetch community posts (${res.status})`);
+      }
+      return res.json();
+    },
+    getNextPageParam: (lastPage) =>
+      lastPage?.pagination?.hasMore ? lastPage.pagination.page + 1 : undefined,
   });
+
+  const posts = postsPages?.pages?.flatMap((page) => page.posts ?? []) ?? [];
+  const postsLoading = postsInitialLoading && !postsPages;
 
   // Fetch challenges
   const { data: challenges = [] } = useQuery<Challenge[]>({
@@ -451,9 +481,10 @@ export default function Community() {
                     </CardContent>
                   </Card>
                 ) : (
-                  posts.map((post: CommunityPost) => (
-                    <Card key={post.id} className="hover:shadow-md transition-shadow">
-                      <CardContent className="p-4 sm:p-6">
+                  <>
+                    {posts.map((post: CommunityPost) => (
+                      <Card key={post.id} className="hover:shadow-md transition-shadow">
+                        <CardContent className="p-4 sm:p-6">
                         <div className="flex items-start justify-between">
                           <div className="flex-1">
                             <div className="flex items-center gap-2 sm:gap-3 mb-3">
@@ -564,9 +595,22 @@ export default function Community() {
                             </div>
                           </div>
                         </div>
-                      </CardContent>
-                    </Card>
-                  ))
+                        </CardContent>
+                      </Card>
+                    ))}
+                    {hasNextPage && (
+                      <div className="flex justify-center pt-2">
+                        <Button
+                          onClick={() => fetchNextPage()}
+                          disabled={isFetchingNextPage}
+                          variant="outline"
+                          className="min-w-[160px]"
+                        >
+                          {isFetchingNextPage ? 'Loading more...' : 'Load more posts'}
+                        </Button>
+                      </div>
+                    )}
+                  </>
                 )}
               </TabsContent>
             </Tabs>

--- a/migrations/0004_community_post_metadata.sql
+++ b/migrations/0004_community_post_metadata.sql
@@ -1,0 +1,20 @@
+-- Ensure community_posts has the extended metadata columns used by the application
+ALTER TABLE community_posts
+  ADD COLUMN IF NOT EXISTS project_url text;
+
+ALTER TABLE community_posts
+  ADD COLUMN IF NOT EXISTS image_url text;
+
+ALTER TABLE community_posts
+  ADD COLUMN IF NOT EXISTS view_count integer DEFAULT 0;
+
+ALTER TABLE community_posts
+  ADD COLUMN IF NOT EXISTS is_pinned boolean DEFAULT false;
+
+ALTER TABLE community_posts
+  ADD COLUMN IF NOT EXISTS is_locked boolean DEFAULT false;
+
+-- Backfill defaults for existing rows to maintain data consistency
+UPDATE community_posts SET view_count = 0 WHERE view_count IS NULL;
+UPDATE community_posts SET is_pinned = false WHERE is_pinned IS NULL;
+UPDATE community_posts SET is_locked = false WHERE is_locked IS NULL;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1754571040706,
       "tag": "0003_notification_preferences_fk_fix",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1754571041706,
+      "tag": "0004_community_post_metadata",
+      "breakpoints": true
     }
   ]
 }

--- a/server/community/community-service.ts
+++ b/server/community/community-service.ts
@@ -103,7 +103,13 @@ export class CommunityService {
 
   async getCommunityPosts(req: Request, res: Response) {
     try {
-      const { category, search } = req.query;
+      const { category, search, tag } = req.query;
+      const parsedPage = Number.parseInt((req.query.page as string) ?? '', 10);
+      const parsedPageSize = Number.parseInt((req.query.pageSize as string) ?? '', 10);
+      const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
+      const pageSizeRaw = Number.isFinite(parsedPageSize) && parsedPageSize > 0 ? parsedPageSize : 20;
+      const pageSize = Math.min(50, pageSizeRaw);
+      const offset = (page - 1) * pageSize;
       const currentUserId = req.user?.id as string | undefined;
 
       const conditions: SQL[] = [];
@@ -116,6 +122,18 @@ export class CommunityService {
           sql`(${communityPosts.title} ILIKE ${term} OR ${communityPosts.content} ILIKE ${term} OR ${communityPosts.tags}::text ILIKE ${term})`,
         );
       }
+      const tagValue = Array.isArray(tag) ? tag[0] : tag;
+      if (tagValue) {
+        conditions.push(sql`${communityPosts.tags} @> ${JSON.stringify([tagValue])}::jsonb`);
+      }
+
+      const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
+
+      let totalQuery = db.select({ total: sql`COUNT(*)` }).from(communityPosts);
+      if (whereCondition) {
+        totalQuery = totalQuery.where(whereCondition);
+      }
+      const [{ total }] = await totalQuery;
 
       let query = db
         .select({
@@ -158,9 +176,11 @@ export class CommunityService {
         )
         .orderBy(desc(communityPosts.createdAt));
 
-      if (conditions.length > 0) {
-        query = query.where(and(...conditions));
+      if (whereCondition) {
+        query = query.where(whereCondition);
       }
+
+      query = query.limit(pageSize).offset(offset);
 
       const posts = await query;
       const postIds = posts.map((post) => post.id).filter((id) => id != null);
@@ -211,7 +231,18 @@ export class CommunityService {
         };
       });
 
-      res.json(response);
+      const totalCount = Number(total ?? 0);
+
+      res.json({
+        posts: response,
+        pagination: {
+          page,
+          pageSize,
+          total: totalCount,
+          totalPages: totalCount === 0 ? 1 : Math.ceil(totalCount / pageSize),
+          hasMore: page * pageSize < totalCount,
+        },
+      });
     } catch (error) {
       logger.error('Error fetching community posts', error);
       res.status(500).json({ message: 'Failed to fetch community posts' });


### PR DESCRIPTION
## Summary
- add pagination, tag filtering, and metadata response to the community posts API to limit memory usage
- update community surfaces to consume paginated responses with an infinite scrolling "load more" experience
- backfill missing community_posts metadata columns via a defensive migration

## Testing
- npm run lint *(fails: existing lint errors and warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f60a8f8b848320b104804ebb6342a8