### PR TITLE
Ensure light theme headers render solid white backgrounds

### DIFF
--- a/client/src/components/MobileHeader.tsx
+++ b/client/src/components/MobileHeader.tsx
@@ -101,7 +101,7 @@ export function MobileHeader() {
   };
   
   return (
-    <header className="fixed top-0 left-0 right-0 h-14 bg-[var(--ecode-surface)] border-b border-[var(--ecode-border)] z-50 md:hidden">
+    <header className="fixed top-0 left-0 right-0 h-14 bg-[#ffffff] dark:bg-[var(--ecode-surface)] border-b border-[var(--ecode-border)] z-50 md:hidden">
       <div className="px-3 h-full flex items-center">
         {getHeaderContent()}
       </div>

--- a/client/src/components/TopNavbar.tsx
+++ b/client/src/components/TopNavbar.tsx
@@ -116,7 +116,7 @@ const TopNavbar = ({
         />
       )}
 
-      <div className="h-14 border-b border-[var(--ecode-border)] bg-[var(--ecode-surface)]/95 backdrop-blur-sm flex items-center justify-between px-4 shadow-[0_1px_0_rgba(12,18,32,0.05)]">
+      <div className="h-14 border-b border-[var(--ecode-border)] bg-[#ffffff] dark:bg-[var(--ecode-surface)]/95 backdrop-blur-sm flex items-center justify-between px-4 shadow-[0_1px_0_rgba(12,18,32,0.05)]">
         <div className="flex items-center gap-4">
           <TooltipProvider>
             <Tooltip>

--- a/client/src/components/layout/PublicNavbar.tsx
+++ b/client/src/components/layout/PublicNavbar.tsx
@@ -201,7 +201,7 @@ export function PublicNavbar() {
 
   return (
     <header className="sticky top-0 z-50 w-full">
-      <div className="hidden md:block border-b border-[var(--ecode-border)] dark:border-white/10 bg-[var(--ecode-accent)]/5 dark:bg-gradient-to-r dark:from-sky-500/20 dark:via-indigo-500/20 dark:to-purple-500/20">
+      <div className="hidden md:block border-b border-[var(--ecode-border)] dark:border-white/10 bg-[#ffffff] dark:bg-gradient-to-r dark:from-sky-500/20 dark:via-indigo-500/20 dark:to-purple-500/20">
         <div className="container-responsive flex h-10 items-center justify-between text-xs text-[var(--ecode-text)] dark:text-slate-100">
           <div className="flex items-center gap-3">
             <Badge variant="secondary" className="bg-[var(--ecode-accent)]/10 text-[var(--ecode-accent)] dark:bg-white/15 dark:text-white border-[var(--ecode-accent)]/20 dark:border-white/25 uppercase tracking-[0.2em]">
@@ -219,7 +219,7 @@ export function PublicNavbar() {
         </div>
       </div>
 
-      <nav className="relative border-b border-[var(--ecode-border)] bg-[var(--ecode-surface)]/95 dark:border-white/10 dark:bg-slate-950/75 backdrop-blur-xl">
+      <nav className="relative border-b border-[var(--ecode-border)] bg-[#ffffff] dark:border-white/10 dark:bg-slate-950/75 backdrop-blur-xl">
         <div className="absolute inset-0 marketing-grid opacity-0 dark:opacity-100" aria-hidden />
         <div className="container-responsive relative">
           <div className="flex h-16 items-center justify-between">

--- a/client/src/components/layout/ReplitHeader.tsx
+++ b/client/src/components/layout/ReplitHeader.tsx
@@ -124,7 +124,7 @@ export function ReplitHeader() {
 
   return (
     <>
-    <header className="replit-header h-14 bg-[var(--ecode-surface)] border-b border-[var(--ecode-border)] flex items-center justify-between px-4 replit-transition">
+    <header className="replit-header h-14 bg-[#ffffff] dark:bg-[var(--ecode-surface)] border-b border-[var(--ecode-border)] flex items-center justify-between px-4 replit-transition">
       {/* Logo et navigation principale */}
       <div className="flex items-center gap-4">
         {/* Mobile menu button - only on mobile */}


### PR DESCRIPTION
## Summary
- set the announcement banner and marketing navigation backgrounds to #FFFFFF in light mode
- update workspace, mobile, and replit headers to use #FFFFFF backgrounds for the light theme

## Testing
- npm test *(fails: TransformError in test/setup/test-runner.ts:32:7 due to "Unexpected ':'")*

------
https://chatgpt.com/codex/tasks/task_e_68f61243a71c8320918aaa027773e696