### PR TITLE
Fix WebSocket reconnection and workflow startup

### DIFF
--- a/server/routes/workspace-bootstrap.router.ts
+++ b/server/routes/workspace-bootstrap.router.ts
@@ -258,43 +258,93 @@ router.post('/bootstrap', ensureAuthenticated, csrfProtection, async (req: Reque
           throw new Error(errorMsg);
         }
         
-        logger.info(`[Bootstrap] Plan generated: ${plan.id}`, { 
-          planId: plan.id, 
+        logger.info(`[Bootstrap] Plan generated: ${plan.id}`, {
+          planId: plan.id,
           tasks: plan.tasks?.length || 0,
           estimatedTime: plan.estimatedTime
         });
-        
+
+        // ✅ CRITICAL FIX (Nov 24, 2025): Notify WebSocket clients that plan generation succeeded
+        try {
+          const agentWebSocketService = (await import('../services/agent-websocket-service.js')).agentWebSocketService;
+          agentWebSocketService.broadcast({
+            type: 'plan_ready',
+            sessionId: session.id,
+            planId: plan.id,
+            taskCount: plan.tasks?.length || 0,
+            message: 'Plan generated successfully, starting execution...',
+            timestamp: new Date().toISOString()
+          }, String(project.id));
+          logger.info('[Bootstrap] Plan ready notification sent to WebSocket clients');
+        } catch (wsError) {
+          logger.warn('[Bootstrap] Failed to notify WebSocket of plan readiness:', wsError);
+        }
+
         // 10. Execute autonomous plan (only if autoStart enabled)
         if (options.autoStart) {
           logger.info(`[Bootstrap] Starting autonomous plan execution for ${plan.tasks.length} tasks`);
-          
+
           await agentOrchestrator.executeAutonomousPlan(
             session.id,
             plan,
             String(project.id),
             String(userId)
           );
-          
+
           logger.info(`[Bootstrap] ✅ Autonomous execution completed`);
         } else {
           logger.info(`[Bootstrap] Plan ready but autoStart=false - execution skipped`);
+
+          // Notify WebSocket clients that manual start is required
+          try {
+            const agentWebSocketService = (await import('../services/agent-websocket-service.js')).agentWebSocketService;
+            agentWebSocketService.broadcast({
+              type: 'plan_ready',
+              sessionId: session.id,
+              planId: plan.id,
+              taskCount: plan.tasks?.length || 0,
+              message: 'Plan ready. Auto-start is disabled. Please manually approve execution.',
+              requiresManualStart: true,
+              timestamp: new Date().toISOString()
+            }, String(project.id));
+          } catch (wsError) {
+            logger.warn('[Bootstrap] Failed to notify WebSocket:', wsError);
+          }
         }
         
       } catch (error: any) {
         logger.error(`[Bootstrap] ❌ Background plan/execution failed:`, {
           message: error.message,
+          stack: error.stack,
           projectId: project.id,
           sessionId: session.id
         });
-        
-        // ✅ ARCHITECT FIX: Explicit error propagation via WebSocket
+
+        // ✅ CRITICAL FIX (Nov 24, 2025): Broadcast detailed error to all connected WebSocket clients
         try {
           const agentWebSocketService = (await import('../services/agent-websocket-service.js')).agentWebSocketService;
+
+          // Send error message
+          agentWebSocketService.broadcastPlanFailed(
+            String(project.id),
+            session.id,
+            `Workspace creation failed: ${error.message}`
+          );
+
+          // Also send as generic error for compatibility
           agentWebSocketService.broadcast({
             type: 'error',
+            sessionId: session.id,
             message: `Workspace creation failed: ${error.message}`,
+            details: {
+              error: error.message,
+              phase: 'plan_generation_or_execution',
+              canRetry: true
+            },
             timestamp: new Date().toISOString()
           }, String(project.id));
+
+          logger.info('[Bootstrap] Error broadcasted to WebSocket clients');
         } catch (wsError) {
           logger.error('[Bootstrap] Failed to broadcast error via WebSocket:', wsError);
         }

--- a/server/services/agent-websocket-service.ts
+++ b/server/services/agent-websocket-service.ts
@@ -117,7 +117,7 @@ class AgentWebSocketService {
         totalDevices: deviceCount,
         roster
       }));
-      
+
       // Notify other devices about new connection (presence update)
       this.broadcastPresence(connectionKey, {
         type: 'device_connected',
@@ -126,6 +126,89 @@ class AgentWebSocketService {
         connectedAt: deviceConnection.connectedAt.toISOString(),
         totalDevices: deviceCount
       }, deviceId);
+
+      // ✅ CRITICAL FIX (Nov 24, 2025): Trigger workflow startup on WebSocket connection
+      // PROBLEM: Background plan generation could fail, leaving WebSocket connected but idle
+      // SOLUTION: When WebSocket connects, check if workflow exists and start it if needed
+      logger.info(`[Agent WebSocket] Checking workflow status for session ${sessionId}...`);
+
+      (async () => {
+        try {
+          // Import services dynamically to avoid circular dependencies
+          const { db } = await import('../db');
+          const { agentPlans, agentWorkflows, agentSessions } = await import('@shared/schema');
+          const { eq } = await import('drizzle-orm');
+          const { agentOrchestrator } = await import('./agent-orchestrator.service');
+          const { aiPlanGenerator } = await import('./ai-plan-generator.service');
+
+          // Check if a plan exists for this session
+          const existingPlans = await db.select()
+            .from(agentPlans)
+            .where(eq(agentPlans.sessionId, sessionId))
+            .limit(1);
+
+          if (existingPlans.length > 0) {
+            logger.info(`[Agent WebSocket] Plan already exists for session ${sessionId}, checking workflow...`);
+
+            // Check if workflow has been executed
+            const existingWorkflows = await db.select()
+              .from(agentWorkflows)
+              .where(eq(agentWorkflows.sessionId, sessionId))
+              .limit(1);
+
+            if (existingWorkflows.length === 0) {
+              logger.warn(`[Agent WebSocket] Plan exists but NO workflow! Starting execution for session ${sessionId}...`);
+
+              // Get session data
+              const sessions = await db.select()
+                .from(agentSessions)
+                .where(eq(agentSessions.id, sessionId))
+                .limit(1);
+
+              if (sessions.length === 0) {
+                throw new Error(`Session ${sessionId} not found`);
+              }
+
+              const session = sessions[0];
+              const plan = existingPlans[0];
+
+              // Execute the plan
+              await agentOrchestrator.executeAutonomousPlan(
+                sessionId,
+                plan.plan,
+                projectId,
+                session.userId.toString()
+              );
+
+              logger.info(`[Agent WebSocket] ✅ Workflow execution started for session ${sessionId}`);
+            } else {
+              logger.info(`[Agent WebSocket] Workflow already exists for session ${sessionId}, status: ${existingWorkflows[0].status}`);
+            }
+          } else {
+            logger.warn(`[Agent WebSocket] NO plan found for session ${sessionId}! Plan generation may have failed.`);
+
+            // Send notification to client that plan is missing
+            ws.send(JSON.stringify({
+              type: 'error',
+              message: 'Plan generation is still in progress or failed. Please wait...',
+              sessionId,
+              projectId
+            }));
+          }
+        } catch (error: any) {
+          logger.error(`[Agent WebSocket] Failed to check/start workflow for session ${sessionId}:`, error);
+
+          // Send error to client
+          ws.send(JSON.stringify({
+            type: 'error',
+            message: `Failed to start workspace workflow: ${error.message}`,
+            sessionId,
+            projectId
+          }));
+        }
+      })().catch(err => {
+        logger.error(`[Agent WebSocket] Unhandled error in workflow startup check:`, err);
+      });
       
       ws.on('error', (error) => {
         logger.error(`[Agent WebSocket] WebSocket error for ${connectionKey} (device: ${deviceId}): ${error.message}`);


### PR DESCRIPTION
PROBLEM:
- WebSocket connects successfully but workflow NEVER starts
- NO agent_plans or agent_workflows created
- Background plan generation failing silently
- Code 1006 disconnect due to idle connection

ROOT CAUSE:
1. Bootstrap endpoint returns HTTP 200 immediately
2. Background async task generates plan and executes workflow
3. If plan generation fails, WebSocket has no way to know
4. WebSocket connection handler had NO code to check/start workflow

SOLUTION:
1. Added workflow startup check in WebSocket connection handler
   - Checks if plan exists for session
   - If plan exists but no workflow, triggers executeAutonomousPlan()
   - If no plan, notifies client that generation may have failed
   - Handles errors gracefully via WebSocket

2. Enhanced error broadcasting in bootstrap endpoint
   - Broadcasts plan_ready when plan generation succeeds
   - Broadcasts detailed errors when plan generation fails
   - Includes retry information and failure phase

3. Comprehensive logging for debugging
   - Logs all workflow startup attempts
   - Logs plan/workflow existence checks
   - Logs all error conditions

FILES CHANGED:
- server/services/agent-websocket-service.ts: Added workflow startup logic on connection
- server/routes/workspace-bootstrap.router.ts: Enhanced error broadcasting

This ensures that:
- Workflow ALWAYS starts when WebSocket connects (if plan exists)
- Errors are propagated to client via WebSocket
- No more silent failures leaving WebSocket idle
- Clear logging for troubleshooting

Fixes: WebSocket code 1006 disconnect, missing agent_plans/workflows