### PR TITLE
feat(phase2-screenshots): make Screenshots panel fully functional + agent tool

### DIFF
--- a/client/src/components/ScreenshotsPanel.tsx
+++ b/client/src/components/ScreenshotsPanel.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
-import { Camera, Download, Trash2 } from 'lucide-react';
+import { Camera, Download, Trash2, ImageOff } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { format } from 'date-fns';
 
@@ -12,58 +11,86 @@ interface ScreenshotsPanelProps {
   projectId: number;
 }
 
+interface Screenshot {
+  id: number;
+  projectId: number;
+  title?: string;
+  name?: string;
+  description?: string;
+  imageUrl: string;
+  thumbnailUrl?: string;
+  deviceType?: string;
+  createdAt?: string;
+}
+
+function formatDate(value?: string): string {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  try {
+    return format(date, 'PP');
+  } catch {
+    return '';
+  }
+}
+
 export function ScreenshotsPanel({ projectId }: ScreenshotsPanelProps) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [screenshotTitle, setScreenshotTitle] = useState('');
   const [screenshotDescription, setScreenshotDescription] = useState('');
+  const [deviceType, setDeviceType] = useState<'desktop' | 'tablet' | 'mobile'>('desktop');
 
-  // Fetch screenshots
-  const { data: screenshots, isLoading } = useQuery({
+  const { data: screenshots, isLoading } = useQuery<Screenshot[]>({
     queryKey: ['/api/screenshots', projectId],
-    queryFn: async () => {
-      const res = await apiRequest('GET', `/api/screenshots/${projectId}`);
-      if (!res.ok) throw new Error('Failed to fetch screenshots');
-      return res.json();
-    }
+    queryFn: () => apiRequest<Screenshot[]>('GET', `/api/screenshots/${projectId}`),
   });
 
-  // Capture screenshot mutation
   const captureScreenshotMutation = useMutation({
-    mutationFn: async () => {
-      const res = await apiRequest('POST', `/api/screenshots/${projectId}/capture`, {
-        title: screenshotTitle || `Screenshot ${new Date().toISOString()}`,
-        description: screenshotDescription
-      });
-      if (!res.ok) throw new Error('Failed to capture screenshot');
-      return res.json();
-    },
+    mutationFn: () =>
+      apiRequest<Screenshot>('POST', `/api/screenshots/${projectId}/capture`, {
+        title: screenshotTitle || undefined,
+        description: screenshotDescription || undefined,
+        deviceType,
+      }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/screenshots', projectId] });
       toast({
         title: 'Screenshot captured',
-        description: 'Project preview has been saved'
+        description: 'Project preview has been saved',
       });
       setScreenshotTitle('');
       setScreenshotDescription('');
-    }
+    },
+    onError: (error: Error) => {
+      toast({
+        title: 'Capture failed',
+        description: error?.message || 'Could not capture screenshot',
+        variant: 'destructive',
+      });
+    },
   });
 
-  // Delete screenshot mutation
   const deleteScreenshotMutation = useMutation({
-    mutationFn: async (screenshotId: number) => {
-      const res = await apiRequest('DELETE', `/api/screenshots/${screenshotId}`);
-      if (!res.ok) throw new Error('Failed to delete screenshot');
-      return res.json();
-    },
+    mutationFn: (screenshotId: number) =>
+      apiRequest<{ success: boolean }>('DELETE', `/api/screenshots/${screenshotId}`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/screenshots', projectId] });
       toast({
         title: 'Screenshot deleted',
-        description: 'The screenshot has been removed'
+        description: 'The screenshot has been removed',
       });
-    }
+    },
+    onError: (error: Error) => {
+      toast({
+        title: 'Delete failed',
+        description: error?.message || 'Could not delete screenshot',
+        variant: 'destructive',
+      });
+    },
   });
+
+  const items = screenshots ?? [];
 
   return (
     <div className="p-4">
@@ -88,57 +115,83 @@ export function ScreenshotsPanel({ projectId }: ScreenshotsPanelProps) {
           className="w-full p-2 mb-2 border rounded h-20"
           aria-label="Screenshot description"
         />
+        <label htmlFor="screenshot-device" className="sr-only">Device type</label>
+        <select
+          id="screenshot-device"
+          value={deviceType}
+          onChange={(e) => setDeviceType(e.target.value as 'desktop' | 'tablet' | 'mobile')}
+          className="w-full p-2 mb-2 border rounded"
+          aria-label="Device type"
+        >
+          <option value="desktop">Desktop (1920×1080)</option>
+          <option value="tablet">Tablet (1024×768)</option>
+          <option value="mobile">Mobile (390×844)</option>
+        </select>
         <Button
-          onClick={() => captureScreenshotMutation.mutate()}
+          onClick={() => captureScreenshotMutation.mutate(undefined)}
           disabled={captureScreenshotMutation.isPending}
           className="w-full"
         >
           <Camera className="h-4 w-4 mr-2" />
-          Capture Screenshot
+          {captureScreenshotMutation.isPending ? 'Capturing…' : 'Capture Screenshot'}
         </Button>
       </div>
 
       <div>
         <h3 className="text-[15px] font-semibold mb-2">Screenshots Gallery</h3>
         {isLoading ? (
-          <p>Loading screenshots...</p>
+          <p className="text-sm text-muted-foreground">Loading screenshots…</p>
+        ) : items.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-10 text-center text-muted-foreground">
+            <ImageOff className="h-8 w-8 mb-2 opacity-60" />
+            <p className="text-sm font-medium">No screenshots yet</p>
+            <p className="text-xs mt-1">Capture a snapshot of your preview to see it here.</p>
+          </div>
         ) : (
           <div className="grid grid-cols-2 gap-2">
-            {screenshots?.map((screenshot: any) => (
-              <Card key={screenshot.id} className="overflow-hidden">
-                <img
-                  src={screenshot.imageUrl}
-                  alt={screenshot.title}
-                  className="w-full h-32 object-cover"
-                />
-                <div className="p-2">
-                  <h4 className="font-medium text-[13px] truncate">{screenshot.title}</h4>
-                  {screenshot.description && (
-                    <p className="text-[11px] text-muted-foreground truncate">{screenshot.description}</p>
-                  )}
-                  <p className="text-[11px] text-muted-foreground mt-1">
-                    {format(new Date(screenshot.createdAt), 'PP')}
-                  </p>
-                  <div className="flex gap-1 mt-2">
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => window.open(screenshot.imageUrl, '_blank')}
-                    >
-                      <Download className="h-3 w-3" />
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => deleteScreenshotMutation.mutate(screenshot.id)}
-                      disabled={deleteScreenshotMutation.isPending}
-                    >
-                      <Trash2 className="h-3 w-3" />
-                    </Button>
+            {items.map((screenshot) => {
+              const label = screenshot.title || screenshot.name || `Screenshot ${screenshot.id}`;
+              const dateLabel = formatDate(screenshot.createdAt);
+              return (
+                <Card key={screenshot.id} className="overflow-hidden">
+                  <img
+                    src={screenshot.thumbnailUrl || screenshot.imageUrl}
+                    alt={label}
+                    className="w-full h-32 object-cover bg-muted"
+                  />
+                  <div className="p-2">
+                    <h4 className="font-medium text-[13px] truncate">{label}</h4>
+                    {screenshot.description && (
+                      <p className="text-[11px] text-muted-foreground truncate">{screenshot.description}</p>
+                    )}
+                    {dateLabel && (
+                      <p className="text-[11px] text-muted-foreground mt-1">{dateLabel}</p>
+                    )}
+                    <div className="flex gap-1 mt-2">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() =>
+                          window.open(`/api/screenshots/${screenshot.id}/download`, '_blank', 'noopener')
+                        }
+                        aria-label="Download screenshot"
+                      >
+                        <Download className="h-3 w-3" />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => deleteScreenshotMutation.mutate(screenshot.id)}
+                        disabled={deleteScreenshotMutation.isPending}
+                        aria-label="Delete screenshot"
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
+                    </div>
                   </div>
-                </div>
-              </Card>
-            ))}
+                </Card>
+              );
+            })}
           </div>
         )}
       </div>

--- a/client/src/components/ide/PreviewPanel.tsx
+++ b/client/src/components/ide/PreviewPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Globe, RefreshCw, ExternalLink, Play, Square, Loader2, AlertCircle } from 'lucide-react';
+import { Globe, RefreshCw, ExternalLink, Play, Square, Loader2, AlertCircle, Camera } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { apiRequest } from '@/lib/queryClient';
@@ -92,6 +92,23 @@ export function PreviewPanel({
         variant: 'destructive'
       });
     }
+  });
+
+  // Capture screenshot mutation
+  const captureScreenshotMutation = useMutation({
+    mutationFn: async () => {
+      return apiRequest('POST', `/api/screenshots/${projectId}/capture`, { deviceType: 'desktop' });
+    },
+    onSuccess: () => {
+      toast({ title: 'Screenshot captured', description: 'Saved to the Screenshots panel.' });
+    },
+    onError: (error: any) => {
+      toast({
+        title: 'Screenshot failed',
+        description: error?.message || 'Could not capture screenshot',
+        variant: 'destructive',
+      });
+    },
   });
 
   // Stop preview mutation
@@ -250,6 +267,21 @@ export function PreviewPanel({
                 className="h-7 w-7 p-0 rounded-md text-[var(--ecode-text-muted)] hover:text-[var(--ecode-text)] hover:bg-[var(--ecode-sidebar-hover)]"
               >
                 <RefreshCw className={cn("h-3.5 w-3.5", isRefreshing && "animate-spin")} />
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => captureScreenshotMutation.mutate(undefined)}
+                disabled={captureScreenshotMutation.isPending}
+                data-testid="button-capture-screenshot"
+                title="Capture screenshot"
+                className="h-7 w-7 p-0 rounded-md text-[var(--ecode-text-muted)] hover:text-[var(--ecode-text)] hover:bg-[var(--ecode-sidebar-hover)]"
+              >
+                {captureScreenshotMutation.isPending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Camera className="h-3.5 w-3.5" />
+                )}
               </Button>
               <Button
                 variant="ghost"

--- a/client/src/components/ide/UnifiedIDELayout.tsx
+++ b/client/src/components/ide/UnifiedIDELayout.tsx
@@ -126,6 +126,7 @@ const AppStoragePanel = instrumentedLazy(() => import('@/components/editor/AppSt
 const ReplitConsolePanel = instrumentedLazy(() => import('@/components/ide/ReplitConsolePanel').then(mod => ({ default: mod.ReplitConsolePanel })), 'ReplitConsolePanel');
 const ResourcesPanel = instrumentedLazy(() => import('@/components/ide/ResourcesPanel').then(mod => ({ default: mod.ResourcesPanel })), 'ResourcesPanel');
 const LogsViewerPanel = instrumentedLazy(() => import('@/components/ide/LogsViewerPanel').then(mod => ({ default: mod.LogsViewerPanel })), 'LogsViewerPanel');
+const ScreenshotsPanel = instrumentedLazy(() => import('@/components/ScreenshotsPanel').then(mod => ({ default: mod.ScreenshotsPanel })), 'ScreenshotsPanel');
 
 import { ShortcutHint, ShortcutTester } from '@/components/utilities';
 import { useAutonomousBuildStore } from '@/stores/autonomousBuildStore';
@@ -534,7 +535,8 @@ function UnifiedIDELayout({
     networking: 'Networking', publishing: 'Publishing', skills: 'Skills',
     ssh: 'SSH', threads: 'Threads', 'test-runner': 'Test Runner',
     'security-scanner': 'Scanner', backup: 'Backup',
-    actions: 'Actions', tools: 'Tools', 'app-storage': 'App Storage'
+    actions: 'Actions', tools: 'Tools', 'app-storage': 'App Storage',
+    screenshots: 'Screenshots'
   };
 
   // Add a new tab when tool is selected from tools sheet
@@ -1345,6 +1347,15 @@ function UnifiedIDELayout({
       return (
         <Suspense fallback={<div className="flex items-center justify-center h-full"><ECodeLoading size="md" text="Loading Logs..." /></div>}>
           <LogsViewerPanel projectId={projectId} />
+        </Suspense>
+      );
+    }
+
+    // Screenshots - inline
+    if (currentTab.id === 'screenshots') {
+      return (
+        <Suspense fallback={<div className="flex items-center justify-center h-full"><ECodeLoading size="md" text="Loading Screenshots..." /></div>}>
+          <ScreenshotsPanel projectId={Number(projectId)} />
         </Suspense>
       );
     }

--- a/client/src/hooks/useIDEWorkspace.ts
+++ b/client/src/hooks/useIDEWorkspace.ts
@@ -172,6 +172,7 @@ export const availableTools: AvailableTool[] = [
   { id: 'multiplayers', label: 'Multiplayer', icon: '👥' },
   { id: 'deploy', label: 'Deploy', icon: '🚀' },
   { id: 'preview', label: 'Preview', icon: '👁️' },
+  { id: 'screenshots', label: 'Screenshots', icon: '📸' },
 ];
 
 export function useIDEWorkspace(projectId: string) {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -95,6 +95,7 @@ import statusRouter from './status.router';
 import mcpServersRouter from './mcp-servers.router';
 import networkingRouter from './networking.router';
 import videoRouter from './video.router';
+import screenshotsRouter from './screenshots.router';
 import { setupPreviewRoutes } from '../preview/preview-service';
 
 const lazyAgentRouter = async (req: any, res: any, next: any) => {
@@ -603,6 +604,9 @@ export class MainRouter {
 
     // Project Auth — authentication configuration per project (/api/project-auth/*)
     app.use('/api/project-auth', tierRateLimiters.api, projectAuthRouter);
+
+    // Screenshots routes — capture, list, download, delete project preview screenshots
+    app.use('/api/screenshots', tierRateLimiters.api, screenshotsRouter);
 
     // Preview proxy routes — proxies HTTP/WebSocket traffic to project preview ports
     setupPreviewRoutes(app);

--- a/server/routes/screenshots.router.ts
+++ b/server/routes/screenshots.router.ts
@@ -1,0 +1,211 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { createLogger } from '../utils/logger';
+import { db } from '../db';
+import { projectScreenshots, projects } from '@shared/schema';
+import { eq, desc } from 'drizzle-orm';
+import { ensureAuthenticated } from '../middleware/auth';
+import { csrfProtection } from '../middleware/csrf';
+import { screenshotService } from '../services/screenshot-service';
+
+const router = Router();
+const logger = createLogger('screenshots');
+
+router.use(ensureAuthenticated);
+
+router.use((req, res, next) => {
+  if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
+    return csrfProtection(req, res, next);
+  }
+  return next();
+});
+
+const captureSchema = z.object({
+  url: z.string().url().optional(),
+  fullPage: z.boolean().optional().default(false),
+  deviceType: z.enum(['desktop', 'tablet', 'mobile']).optional().default('desktop'),
+  title: z.string().max(200).optional(),
+  description: z.string().max(2000).optional(),
+});
+
+async function assertProjectAccess(userId: number, projectId: number): Promise<boolean> {
+  if (!Number.isFinite(userId) || !Number.isFinite(projectId) || userId <= 0 || projectId <= 0) {
+    return false;
+  }
+  const [project] = await db.select().from(projects).where(eq(projects.id, projectId)).limit(1);
+  if (!project) return false;
+  return project.ownerId === userId;
+}
+
+function toApiShape(row: typeof projectScreenshots.$inferSelect) {
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    title: row.title,
+    name: row.title,
+    description: row.description ?? undefined,
+    imageUrl: row.imageUrl,
+    thumbnailUrl: row.imageUrl,
+    url: row.imageUrl,
+    createdAt: row.createdAt?.toISOString?.() ?? row.createdAt,
+    createdBy: row.createdBy,
+  };
+}
+
+// GET /api/screenshots/:projectId — list screenshots for a project
+router.get('/:projectId', async (req, res) => {
+  try {
+    const projectId = parseInt(req.params.projectId, 10);
+    const userId = (req.user as any)?.id;
+
+    if (!Number.isFinite(projectId)) {
+      return res.status(400).json({ error: 'Invalid projectId' });
+    }
+    if (!userId) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+    if (!(await assertProjectAccess(userId, projectId))) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+
+    const rows = await db
+      .select()
+      .from(projectScreenshots)
+      .where(eq(projectScreenshots.projectId, projectId))
+      .orderBy(desc(projectScreenshots.createdAt))
+      .limit(200);
+
+    res.json(rows.map(toApiShape));
+  } catch (error: any) {
+    logger.error('Failed to list screenshots', { error: error?.message });
+    res.status(500).json({ error: 'Failed to list screenshots' });
+  }
+});
+
+// POST /api/screenshots/:projectId/capture — capture a new screenshot
+router.post('/:projectId/capture', async (req, res) => {
+  try {
+    const projectId = parseInt(req.params.projectId, 10);
+    const userId = (req.user as any)?.id;
+
+    if (!Number.isFinite(projectId)) {
+      return res.status(400).json({ error: 'Invalid projectId' });
+    }
+    if (!userId) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+    if (!(await assertProjectAccess(userId, projectId))) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+
+    const parsed = captureSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({ error: 'Invalid request', details: parsed.error.flatten() });
+    }
+    const { fullPage, deviceType, title, description } = parsed.data;
+
+    const captured = await screenshotService.captureProjectPreview(projectId, userId, {
+      storeAsBase64: true,
+      storeInObjectStorage: true,
+      metadata: {
+        deviceType,
+        fullPage: String(fullPage),
+        capturedBy: String(userId),
+      },
+    });
+
+    const imageUrl =
+      (captured as any)?.storageObject?.url ||
+      captured.base64Data ||
+      captured.thumbnail;
+
+    const [row] = await db
+      .insert(projectScreenshots)
+      .values({
+        projectId,
+        title: title ?? `Screenshot ${new Date().toISOString()}`,
+        description: description ?? null,
+        imageUrl,
+        createdBy: userId,
+      })
+      .returning();
+
+    res.status(201).json(toApiShape(row));
+  } catch (error: any) {
+    logger.error('Failed to capture screenshot', { error: error?.message, projectId: req.params.projectId });
+    res.status(500).json({ error: 'Failed to capture screenshot', message: error?.message });
+  }
+});
+
+// GET /api/screenshots/:id/download — stream or redirect to the image
+router.get('/:id/download', async (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const userId = (req.user as any)?.id;
+    if (!Number.isFinite(id)) {
+      return res.status(400).json({ error: 'Invalid screenshot id' });
+    }
+
+    const [row] = await db
+      .select()
+      .from(projectScreenshots)
+      .where(eq(projectScreenshots.id, id))
+      .limit(1);
+    if (!row) return res.status(404).json({ error: 'Screenshot not found' });
+    if (!(await assertProjectAccess(userId, row.projectId))) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+
+    if (row.imageUrl?.startsWith('data:')) {
+      const match = row.imageUrl.match(/^data:([^;]+);base64,(.+)$/);
+      if (match) {
+        res.setHeader('Content-Type', match[1]);
+        res.setHeader(
+          'Content-Disposition',
+          `attachment; filename="screenshot-${row.id}.${match[1].includes('svg') ? 'svg' : 'png'}"`
+        );
+        return res.send(Buffer.from(match[2], 'base64'));
+      }
+    }
+
+    if (row.imageUrl) {
+      return res.redirect(row.imageUrl);
+    }
+
+    res.status(404).json({ error: 'No image data available' });
+  } catch (error: any) {
+    logger.error('Failed to download screenshot', { error: error?.message });
+    res.status(500).json({ error: 'Failed to download screenshot' });
+  }
+});
+
+// DELETE /api/screenshots/:id — delete screenshot
+router.delete('/:id', async (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const userId = (req.user as any)?.id;
+
+    if (!Number.isFinite(id)) {
+      return res.status(400).json({ error: 'Invalid screenshot id' });
+    }
+
+    const [row] = await db
+      .select()
+      .from(projectScreenshots)
+      .where(eq(projectScreenshots.id, id))
+      .limit(1);
+    if (!row) return res.status(404).json({ error: 'Screenshot not found' });
+    if (!(await assertProjectAccess(userId, row.projectId))) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+
+    await db.delete(projectScreenshots).where(eq(projectScreenshots.id, id));
+
+    res.json({ success: true, id });
+  } catch (error: any) {
+    logger.error('Failed to delete screenshot', { error: error?.message });
+    res.status(500).json({ error: 'Failed to delete screenshot' });
+  }
+});
+
+export default router;

--- a/server/services/agent-tool-framework.service.ts
+++ b/server/services/agent-tool-framework.service.ts
@@ -1375,6 +1375,53 @@ export class AgentToolFrameworkService extends EventEmitter {
         };
       }
     });
+
+    // 11. Screenshot capture — lets the agent capture the project preview
+    this.registerTool({
+      name: 'screenshot_capture',
+      displayName: 'Capture Screenshot',
+      description: 'Capture a screenshot of the project preview and persist it in the Screenshots panel',
+      capability: 'testing',
+      inputSchema: z.object({
+        projectId: z.number().optional().describe('Project id (defaults to the current session project)'),
+        url: z.string().url().optional().describe('Optional explicit URL to capture'),
+        deviceType: z.enum(['desktop', 'tablet', 'mobile']).optional().default('desktop'),
+        fullPage: z.boolean().optional().default(false),
+        title: z.string().optional().describe('Optional human-readable title for the screenshot')
+      }),
+      requiresAuth: true,
+      rateLimit: 6,
+      execute: async (input, context) => {
+        const { projectScreenshots } = await import('@shared/schema');
+        const { screenshotService } = await import('./screenshot-service');
+
+        const projectId = input.projectId ?? context.projectId;
+        if (!projectId) throw new Error('projectId is required');
+        const userId = typeof context.userId === 'string' ? parseInt(context.userId, 10) || 0 : context.userId;
+        const deviceType: 'desktop' | 'tablet' | 'mobile' = input.deviceType ?? 'desktop';
+
+        const captured = await screenshotService.captureProjectPreview(projectId, userId, {
+          storeAsBase64: true,
+          storeInObjectStorage: true,
+          metadata: { deviceType, fullPage: String(input.fullPage ?? false), capturedBy: String(userId) }
+        });
+
+        const imageUrl = (captured as any)?.storageObject?.url || captured.base64Data || captured.thumbnail;
+
+        const [row] = await db.insert(projectScreenshots).values({
+          projectId,
+          title: input.title ?? `Agent capture ${new Date().toISOString()}`,
+          imageUrl,
+          createdBy: userId
+        }).returning();
+
+        return {
+          id: row.id,
+          imageUrl: row.imageUrl,
+          createdAt: row.createdAt
+        };
+      }
+    });
   }
 
   // Register a custom tool


### PR DESCRIPTION
## Summary
- Adds `/api/screenshots` router backed by the existing `screenshot-service` and the existing `projectScreenshots` table, with endpoints for list / capture / download / delete.
- Brings the dormant `ScreenshotsPanel` back online: removes `@ts-nocheck`, fixes the `apiRequest` misuse (it returns parsed JSON), guards date formatting against `RangeError`, and adds empty-state + error toasts. Registers the panel as an openable IDE tool and adds a camera-icon Capture button to the PreviewPanel toolbar.
- Registers a new `screenshot_capture` AI-agent tool so the agent can snapshot the preview and reference the resulting image url in its responses.

## Schema
Reuses the existing `projectScreenshots` table (already wired through `server/storage.ts`). No schema change needed.

## Phase 1 merge-conflict notes
- `server/routes/index.ts`: one import + one `app.use(...)` call appended at the very end of the router-mounting block to minimize conflicts with Phase 1.
- `server/services/agent-tool-framework.service.ts`: a single `this.registerTool({...})` for `screenshot_capture` appended inside `registerBuiltInTools()`. If Phase 1 adds tools in the same method, a small merge conflict is expected and acceptable.
- Phase 2 does not touch `/api/mcp`, `server/api/mcp.ts`, or the 4 MCP panels.

## Test plan
- [x] `pnpm typecheck` — clean, 0 new errors on the branch.
- [x] Boot the server with a placeholder `DATABASE_URL`; `POST /api/screenshots/1/capture` returns 401 (auth required), proving the route is mounted (was 404 before).
- [ ] Log in to the dev IDE, open the Screenshots tool from the tools sheet, capture a screenshot, verify it appears in the gallery, download it, then delete it.
- [ ] Click the new camera button in the Preview panel toolbar; verify it saves into the Screenshots gallery.
- [ ] From an agent session call `screenshot_capture({ projectId })`; verify the tool returns `{ id, imageUrl, createdAt }` and the row appears in the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
