### PR TITLE
feat(phase1-mcp): make MCP suite fully functional + agent tools

### DIFF
--- a/client/src/components/MCPServersPanel.tsx
+++ b/client/src/components/MCPServersPanel.tsx
@@ -1,166 +1,219 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
-import { 
-  Github, 
-  Database, 
+import { useQuery } from '@tanstack/react-query';
+import { PostgreSQLMCPPanel } from '@/components/mcp/PostgreSQLMCPPanel';
+import { GitHubMCPPanel } from '@/components/mcp/GitHubMCPPanel';
+import { MemoryMCPPanel } from '@/components/mcp/MemoryMCPPanel';
+import {
+  Github,
+  Database,
   Brain,
   Server,
   FileText,
   Code,
-  GitBranch,
-  Table,
-  Search,
-  MessageSquare,
-  Clock,
   CheckCircle,
-  AlertCircle
+  AlertCircle,
+  Clock,
 } from 'lucide-react';
 
-interface MCPServer {
+type ServerStatus = 'active' | 'inactive' | 'error' | 'disabled';
+
+interface ServerTool {
+  name: string;
+  description: string;
+}
+
+interface MCPServerDescriptor {
+  id: string;
   name: string;
   description: string;
   icon: React.ReactNode;
-  status: 'active' | 'inactive' | 'error';
-  tools: string[];
   category: string;
+  tools: ServerTool[];
+  endpoints: string[];
+  status: ServerStatus;
 }
 
-export function MCPServersPanel() {
-  const [servers, setServers] = useState<MCPServer[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [selectedServer, setSelectedServer] = useState<string | null>(null);
+interface ServersResponse {
+  servers: Array<{
+    id: string;
+    name: string;
+    status: ServerStatus;
+    endpoints: string[];
+  }>;
+}
+
+const staticServers: Omit<MCPServerDescriptor, 'status'>[] = [
+  {
+    id: 'github',
+    name: 'GitHub MCP',
+    description: 'Manage GitHub repositories, issues, and pull requests',
+    icon: <Github className="w-5 h-5" />,
+    category: 'Version Control',
+    tools: [
+      { name: 'github_list_repos', description: 'List repositories' },
+      { name: 'github_create_repo', description: 'Create repository' },
+      { name: 'github_create_issue', description: 'Create issue' },
+      { name: 'github_search_issues', description: 'Search issues' },
+      { name: 'github_list_prs', description: 'List pull requests' },
+      { name: 'github_create_pr', description: 'Create pull request' },
+    ],
+    endpoints: [
+      '/api/mcp/github/repositories',
+      '/api/mcp/github/issues',
+      '/api/mcp/github/pull-requests',
+    ],
+  },
+  {
+    id: 'postgres',
+    name: 'PostgreSQL MCP',
+    description: 'Execute database queries and manage PostgreSQL databases',
+    icon: <Database className="w-5 h-5" />,
+    category: 'Database',
+    tools: [
+      { name: 'postgres_list_tables', description: 'List database tables' },
+      { name: 'postgres_get_schema', description: 'Inspect table schema' },
+      { name: 'postgres_query', description: 'Execute SQL queries' },
+      { name: 'postgres_backup', description: 'Create a database backup' },
+    ],
+    endpoints: [
+      '/api/mcp/postgres/tables',
+      '/api/mcp/postgres/schema/:table',
+      '/api/mcp/postgres/query',
+      '/api/mcp/postgres/backup',
+    ],
+  },
+  {
+    id: 'memory',
+    name: 'Memory MCP',
+    description: 'Store and retrieve conversation memory and knowledge graphs',
+    icon: <Brain className="w-5 h-5" />,
+    category: 'AI & Memory',
+    tools: [
+      { name: 'memory_search', description: 'Semantic search over memory' },
+      { name: 'memory_create_node', description: 'Add memory node' },
+      { name: 'memory_create_edge', description: 'Link memory nodes' },
+      { name: 'memory_save_conversation', description: 'Persist a conversation' },
+      { name: 'memory_get_history', description: 'Fetch conversation history' },
+    ],
+    endpoints: [
+      '/api/mcp/memory/search',
+      '/api/mcp/memory/conversations',
+      '/api/mcp/memory/nodes',
+      '/api/mcp/memory/edges',
+    ],
+  },
+  {
+    id: 'core',
+    name: 'Core MCP Server',
+    description: 'Filesystem, shell, and runtime tools exposed via the core MCP server',
+    icon: <Server className="w-5 h-5" />,
+    category: 'Core',
+    tools: [
+      { name: 'fs_read', description: 'Read files' },
+      { name: 'fs_write', description: 'Write files' },
+      { name: 'exec_command', description: 'Execute shell commands' },
+      { name: 'ai_complete', description: 'Invoke AI completion' },
+    ],
+    endpoints: ['/mcp/connect', '/mcp/message', '/mcp/disconnect'],
+  },
+  {
+    id: 'filesystem',
+    name: 'Filesystem MCP',
+    description: 'File and directory operations with watch capabilities',
+    icon: <FileText className="w-5 h-5" />,
+    category: 'Core',
+    tools: [
+      { name: 'fs_list', description: 'List directories' },
+      { name: 'fs_search', description: 'Find files' },
+      { name: 'fs_watch', description: 'Watch for changes' },
+    ],
+    endpoints: ['/api/mcp/tools'],
+  },
+  {
+    id: 'execution',
+    name: 'Execution MCP',
+    description: 'Command execution and process management',
+    icon: <Code className="w-5 h-5" />,
+    category: 'Core',
+    tools: [
+      { name: 'exec_spawn', description: 'Spawn processes' },
+      { name: 'process_kill', description: 'Kill processes' },
+    ],
+    endpoints: ['/api/mcp/tools'],
+  },
+];
+
+type SelectedDetail =
+  | { kind: 'panel'; id: 'github' | 'postgres' | 'memory' }
+  | { kind: 'info'; server: MCPServerDescriptor }
+  | null;
+
+export function MCPServersPanel({ projectId }: { projectId?: number } = {}) {
   const { toast } = useToast();
+  const [selected, setSelected] = useState<SelectedDetail>(null);
 
-  useEffect(() => {
-    loadMCPServers();
-  }, []);
+  const { data: remote, isLoading } = useQuery<ServersResponse>({
+    queryKey: ['/api/mcp/servers'],
+    queryFn: () => apiRequest<ServersResponse>('GET', '/api/mcp/servers'),
+    staleTime: 30_000,
+  });
 
-  const loadMCPServers = async () => {
-    try {
-      setLoading(true);
-      
-      // Define the integrated MCP servers
-      const mcpServers: MCPServer[] = [
-        {
-          name: 'GitHub MCP',
-          description: 'Manage GitHub repositories, issues, and pull requests',
-          icon: <Github className="w-5 h-5" />,
-          status: 'active',
-          tools: ['github_list_repos', 'github_create_repo', 'github_create_issue', 'github_create_pr'],
-          category: 'Version Control'
-        },
-        {
-          name: 'PostgreSQL MCP',
-          description: 'Execute database queries and manage PostgreSQL databases',
-          icon: <Database className="w-5 h-5" />,
-          status: 'active',
-          tools: ['postgres_list_tables', 'postgres_get_schema', 'postgres_query', 'postgres_backup'],
-          category: 'Database'
-        },
-        {
-          name: 'Memory MCP',
-          description: 'Manage conversation memory and knowledge graphs',
-          icon: <Brain className="w-5 h-5" />,
-          status: 'active',
-          tools: ['memory_create_node', 'memory_search', 'memory_create_edge', 'memory_save_conversation', 'memory_get_history'],
-          category: 'AI & Memory'
-        },
-        {
-          name: 'Filesystem MCP',
-          description: 'File and directory operations with watch capabilities',
-          icon: <FileText className="w-5 h-5" />,
-          status: 'active',
-          tools: ['fs_read', 'fs_write', 'fs_list', 'fs_delete', 'fs_mkdir', 'fs_move', 'fs_copy', 'fs_search', 'fs_watch'],
-          category: 'Core'
-        },
-        {
-          name: 'Execution MCP',
-          description: 'Command execution and process management',
-          icon: <Code className="w-5 h-5" />,
-          status: 'active',
-          tools: ['exec_command', 'exec_spawn', 'process_kill'],
-          category: 'Core'
-        },
-        {
-          name: 'System MCP',
-          description: 'System information and environment management',
-          icon: <Server className="w-5 h-5" />,
-          status: 'active',
-          tools: ['system_info', 'env_get', 'env_set'],
-          category: 'Core'
-        }
-      ];
+  const remoteStatusById = new Map<string, ServerStatus>();
+  for (const s of remote?.servers ?? []) {
+    remoteStatusById.set(s.id, s.status);
+  }
 
-      setServers(mcpServers);
-    } catch (error) {
-      console.error('Failed to load MCP servers:', error);
-      toast({
-        title: 'Error',
-        description: 'Failed to load MCP servers',
-        variant: 'destructive'
-      });
-    } finally {
-      setLoading(false);
+  const servers: MCPServerDescriptor[] = staticServers.map((server) => {
+    const status = remoteStatusById.get(server.id);
+    return {
+      ...server,
+      status: status ?? (server.category === 'Core' ? 'active' : 'inactive'),
+    };
+  });
+
+  const groupedServers = servers.reduce<Record<string, MCPServerDescriptor[]>>((acc, server) => {
+    (acc[server.category] ||= []).push(server);
+    return acc;
+  }, {});
+
+  const openServer = (server: MCPServerDescriptor) => {
+    if (server.id === 'github' || server.id === 'postgres' || server.id === 'memory') {
+      setSelected({ kind: 'panel', id: server.id });
+    } else {
+      setSelected({ kind: 'info', server });
     }
   };
 
-  const testMCPServer = async (serverName: string) => {
+  const testConnection = async (server: MCPServerDescriptor, e: React.MouseEvent) => {
+    e.stopPropagation();
+    toast({ title: 'Testing MCP Server', description: `Testing ${server.name}...` });
     try {
-      toast({
-        title: 'Testing MCP Server',
-        description: `Testing ${serverName}...`
-      });
-
-      // Test specific server functionality
-      let result;
-      switch (serverName) {
-        case 'GitHub MCP':
-          result = await apiRequest('GET', '/api/mcp/github/repos/octocat');
-          break;
-        case 'PostgreSQL MCP':
-          result = await apiRequest('GET', '/api/mcp/postgres/tables');
-          break;
-        case 'Memory MCP':
-          result = await apiRequest('GET', '/api/mcp/memory/search?query=test&limit=5');
-          break;
-        default:
-          result = await apiRequest('GET', '/api/mcp/tools');
+      if (server.id === 'postgres') {
+        await apiRequest('GET', '/api/mcp/postgres/tables');
+      } else if (server.id === 'github') {
+        await apiRequest('GET', '/api/mcp/github/repositories');
+      } else if (server.id === 'memory') {
+        await apiRequest('POST', '/api/mcp/memory/search', { query: 'health-check', limit: 1 });
+      } else {
+        await apiRequest('GET', '/api/mcp/servers');
       }
-
-      toast({
-        title: 'Success',
-        description: `${serverName} is working correctly`,
-      });
-    } catch (error) {
+      toast({ title: 'Success', description: `${server.name} is reachable` });
+    } catch (error: any) {
       toast({
         title: 'Error',
-        description: `Failed to test ${serverName}`,
-        variant: 'destructive'
+        description: error?.message || `Failed to reach ${server.name}`,
+        variant: 'destructive',
       });
     }
   };
 
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'active':
-        return 'bg-green-500';
-      case 'inactive':
-        return 'bg-gray-400';
-      case 'error':
-        return 'bg-red-500';
-      default:
-        return 'bg-gray-400';
-    }
-  };
-
-  const getStatusIcon = (status: string) => {
+  const getStatusIcon = (status: ServerStatus) => {
     switch (status) {
       case 'active':
         return <CheckCircle className="w-4 h-4 text-green-500" />;
@@ -171,15 +224,9 @@ export function MCPServersPanel() {
     }
   };
 
-  const groupedServers = servers.reduce((acc, server) => {
-    if (!acc[server.category]) {
-      acc[server.category] = [];
-    }
-    acc[server.category].push(server);
-    return acc;
-  }, {} as Record<string, MCPServer[]>);
+  const activeCount = servers.filter((s) => s.status === 'active').length;
 
-  if (loading) {
+  if (isLoading && servers.length === 0) {
     return (
       <div className="flex items-center justify-center h-64">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
@@ -187,8 +234,23 @@ export function MCPServersPanel() {
     );
   }
 
+  if (selected?.kind === 'panel') {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <Button variant="ghost" size="sm" onClick={() => setSelected(null)}>
+            ← Back to MCP Servers
+          </Button>
+        </div>
+        {selected.id === 'github' && <GitHubMCPPanel projectId={projectId} />}
+        {selected.id === 'postgres' && <PostgreSQLMCPPanel projectId={projectId} />}
+        {selected.id === 'memory' && <MemoryMCPPanel projectId={projectId} />}
+      </div>
+    );
+  }
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-6" data-testid="mcp-servers-panel">
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-2xl font-bold">MCP Servers</h2>
@@ -198,7 +260,7 @@ export function MCPServersPanel() {
         </div>
         <Badge variant="outline" className="px-3 py-1">
           <span className="mr-2">●</span>
-          {servers.filter(s => s.status === 'active').length} Active
+          {activeCount} Active
         </Badge>
       </div>
 
@@ -219,17 +281,16 @@ export function MCPServersPanel() {
                 </h3>
                 <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                   {categoryServers.map((server) => (
-                    <Card 
-                      key={server.name}
+                    <Card
+                      key={server.id}
                       className="cursor-pointer hover:shadow-lg transition-shadow"
-                      onClick={() => setSelectedServer(server.name)}
+                      onClick={() => openServer(server)}
+                      data-testid={`mcp-server-card-${server.id}`}
                     >
                       <CardHeader className="pb-4">
                         <div className="flex items-start justify-between">
                           <div className="flex items-center gap-3">
-                            <div className="p-2 rounded-lg bg-primary/10">
-                              {server.icon}
-                            </div>
+                            <div className="p-2 rounded-lg bg-primary/10">{server.icon}</div>
                             <div>
                               <CardTitle className="text-[15px]">{server.name}</CardTitle>
                               <div className="flex items-center gap-2 mt-1">
@@ -243,13 +304,11 @@ export function MCPServersPanel() {
                         </div>
                       </CardHeader>
                       <CardContent>
-                        <CardDescription className="mb-3">
-                          {server.description}
-                        </CardDescription>
+                        <CardDescription className="mb-3">{server.description}</CardDescription>
                         <div className="flex flex-wrap gap-1">
                           {server.tools.slice(0, 3).map((tool) => (
-                            <Badge key={tool} variant="secondary" className="text-[11px]">
-                              {tool.replace(/_/g, ' ')}
+                            <Badge key={tool.name} variant="secondary" className="text-[11px]">
+                              {tool.name.replace(/_/g, ' ')}
                             </Badge>
                           ))}
                           {server.tools.length > 3 && (
@@ -262,10 +321,7 @@ export function MCPServersPanel() {
                           size="sm"
                           variant="outline"
                           className="w-full mt-4"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            testMCPServer(server.name);
-                          }}
+                          onClick={(e) => testConnection(server, e)}
                         >
                           Test Connection
                         </Button>
@@ -280,84 +336,106 @@ export function MCPServersPanel() {
 
         <TabsContent value="core" className="mt-6">
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {servers.filter(s => s.category === 'Core').map((server) => (
-              <Card key={server.name}>
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    {server.icon}
-                    <CardTitle>{server.name}</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription>{server.description}</CardDescription>
-                </CardContent>
-              </Card>
-            ))}
+            {servers
+              .filter((s) => s.category === 'Core')
+              .map((server) => (
+                <Card
+                  key={server.id}
+                  className="cursor-pointer"
+                  onClick={() => openServer(server)}
+                >
+                  <CardHeader>
+                    <div className="flex items-center gap-3">
+                      {server.icon}
+                      <CardTitle>{server.name}</CardTitle>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <CardDescription>{server.description}</CardDescription>
+                  </CardContent>
+                </Card>
+              ))}
           </div>
         </TabsContent>
 
         <TabsContent value="integrations" className="mt-6">
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {servers.filter(s => s.category === 'Version Control' || s.category === 'Database').map((server) => (
-              <Card key={server.name}>
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    {server.icon}
-                    <CardTitle>{server.name}</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription>{server.description}</CardDescription>
-                </CardContent>
-              </Card>
-            ))}
+            {servers
+              .filter((s) => s.category === 'Version Control' || s.category === 'Database')
+              .map((server) => (
+                <Card
+                  key={server.id}
+                  className="cursor-pointer"
+                  onClick={() => openServer(server)}
+                >
+                  <CardHeader>
+                    <div className="flex items-center gap-3">
+                      {server.icon}
+                      <CardTitle>{server.name}</CardTitle>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <CardDescription>{server.description}</CardDescription>
+                  </CardContent>
+                </Card>
+              ))}
           </div>
         </TabsContent>
 
         <TabsContent value="ai" className="mt-6">
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {servers.filter(s => s.category === 'AI & Memory').map((server) => (
-              <Card key={server.name}>
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    {server.icon}
-                    <CardTitle>{server.name}</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription>{server.description}</CardDescription>
-                </CardContent>
-              </Card>
-            ))}
+            {servers
+              .filter((s) => s.category === 'AI & Memory')
+              .map((server) => (
+                <Card
+                  key={server.id}
+                  className="cursor-pointer"
+                  onClick={() => openServer(server)}
+                >
+                  <CardHeader>
+                    <div className="flex items-center gap-3">
+                      {server.icon}
+                      <CardTitle>{server.name}</CardTitle>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <CardDescription>{server.description}</CardDescription>
+                  </CardContent>
+                </Card>
+              ))}
           </div>
         </TabsContent>
       </Tabs>
 
-      {selectedServer && (
+      {selected?.kind === 'info' && (
         <Card className="mt-6">
           <CardHeader>
-            <CardTitle>Server Details: {selectedServer}</CardTitle>
+            <div className="flex items-center justify-between">
+              <CardTitle>Server Details: {selected.server.name}</CardTitle>
+              <Button variant="ghost" size="sm" onClick={() => setSelected(null)}>
+                Close
+              </Button>
+            </div>
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
               <div>
                 <h4 className="text-[13px] font-semibold mb-2">Available Tools</h4>
                 <div className="flex flex-wrap gap-2">
-                  {servers.find(s => s.name === selectedServer)?.tools.map((tool) => (
-                    <Badge key={tool} variant="outline">
-                      {tool}
+                  {selected.server.tools.map((tool) => (
+                    <Badge key={tool.name} variant="outline">
+                      {tool.name}
                     </Badge>
                   ))}
                 </div>
               </div>
               <div>
-                <h4 className="text-[13px] font-semibold mb-2">Connection Status</h4>
-                <div className="flex items-center gap-2">
-                  <div className={`w-2 h-2 rounded-full ${getStatusColor(servers.find(s => s.name === selectedServer)?.status || 'inactive')}`}></div>
-                  <span className="text-[13px]">
-                    Server is {servers.find(s => s.name === selectedServer)?.status}
-                  </span>
-                </div>
+                <h4 className="text-[13px] font-semibold mb-2">Endpoints</h4>
+                <ul className="text-[12px] font-mono text-muted-foreground space-y-1">
+                  {selected.server.endpoints.map((endpoint) => (
+                    <li key={endpoint}>{endpoint}</li>
+                  ))}
+                </ul>
               </div>
             </div>
           </CardContent>

--- a/client/src/components/ide/ReplitActivityBar.tsx
+++ b/client/src/components/ide/ReplitActivityBar.tsx
@@ -23,9 +23,10 @@ import {
   ChevronLeft,
   ChevronRight,
   Search,
+  Brain,
 } from 'lucide-react';
 
-export type ActivityItem = 
+export type ActivityItem =
   | 'files'
   | 'search'
   | 'git'
@@ -36,6 +37,7 @@ export type ActivityItem =
   | 'deploy'
   | 'secrets'
   | 'database'
+  | 'mcp-suite'
   | 'preview'
   | 'workflows'
   | 'extensions'
@@ -70,7 +72,8 @@ const defaultItems: ActivityBarItem[] = [
   { id: 'agent', icon: Bot, label: 'AI Agent', shortcut: '⌘⇧A' },
   { id: 'deploy', icon: Rocket, label: 'Deploy' },
   { id: 'secrets', icon: Key, label: 'Secrets' },
-  { id: 'database', icon: Database, label: 'Database', separator: true },
+  { id: 'database', icon: Database, label: 'Database' },
+  { id: 'mcp-suite', icon: Brain, label: 'MCP Suite', separator: true },
   { id: 'preview', icon: Eye, label: 'Preview', shortcut: '⌘⇧P' },
   { id: 'workflows', icon: Zap, label: 'Workflows' },
 ];

--- a/client/src/components/ide/UnifiedIDELayout.tsx
+++ b/client/src/components/ide/UnifiedIDELayout.tsx
@@ -149,6 +149,7 @@ const FeedbackInboxPanel = instrumentedLazy(() => import('@/components/FeedbackI
 const GitHubPanel = instrumentedLazy(() => import('@/components/GitHubPanel').then(m => m.default ? m : { default: m.GitHubPanel || m }), 'GitHubPanel');
 const IntegrationsPanel = instrumentedLazy(() => import('@/components/IntegrationsPanel').then(m => m.default ? m : { default: m.IntegrationsPanel || m }), 'IntegrationsPanel');
 const MCPPanel = instrumentedLazy(() => import('@/components/MCPPanel').then(m => m.default ? m : { default: m.MCPPanel || m }), 'MCPPanel');
+const MCPServersPanel = instrumentedLazy(() => import('@/components/MCPServersPanel').then(m => m.default ? m : { default: m.MCPServersPanel || m }), 'MCPServersPanel');
 const MergeConflictPanel = instrumentedLazy(() => import('@/components/MergeConflictPanel').then(m => m.default ? m : { default: m.MergeConflictPanel || m }), 'MergeConflictPanel');
 const MonitoringPanel = instrumentedLazy(() => import('@/components/MonitoringPanel').then(m => m.default ? m : { default: m.MonitoringPanel || m }), 'MonitoringPanel');
 const NetworkingPanel = instrumentedLazy(() => import('@/components/NetworkingPanel').then(m => m.default ? m : { default: m.NetworkingPanel || m }), 'NetworkingPanel');
@@ -400,6 +401,10 @@ function UnifiedIDELayout({
       case 'database':
         // Open database as inline tab instead of overlay
         handleAddTool('database');
+        break;
+      case 'mcp-suite':
+        // Open MCP suite (GitHub / PostgreSQL / Memory) as inline tab
+        handleAddTool('mcp-suite');
         break;
       case 'preview':
         handleAddTool('preview');
@@ -927,6 +932,12 @@ function UnifiedIDELayout({
             <WorkflowsPanel projectId={projectId} />
           </Suspense>
         );
+      case 'mcp-suite':
+        return (
+          <Suspense fallback={<div className="flex items-center justify-center h-full"><ECodeLoading size="md" text="Loading MCP Suite..." /></div>}>
+            <MCPServersPanel projectId={projectId ? Number(projectId) : undefined} />
+          </Suspense>
+        );
       case 'debug':
         return (
           <Suspense fallback={<div className="flex items-center justify-center h-full"><ECodeLoading size="md" text="Loading Debug..." /></div>}>
@@ -1429,6 +1440,7 @@ function UnifiedIDELayout({
     if (currentTab.id === 'github') return <Suspense fallback={<ECodeLoading size="md" />}><GitHubPanel projectId={projectId} projectName={projectName} /></Suspense>;
     if (currentTab.id === 'integrations') return <Suspense fallback={<ECodeLoading size="md" />}><IntegrationsPanel projectId={projectId} onClose={() => handleTabClose('integrations')} /></Suspense>;
     if (currentTab.id === 'mcp') return <Suspense fallback={<ECodeLoading size="md" />}><MCPPanel projectId={projectId} onClose={() => handleTabClose('mcp')} /></Suspense>;
+    if (currentTab.id === 'mcp-suite') return <Suspense fallback={<ECodeLoading size="md" />}><MCPServersPanel projectId={projectId ? Number(projectId) : undefined} /></Suspense>;
     if (currentTab.id === 'merge-conflicts') return <Suspense fallback={<ECodeLoading size="md" />}><MergeConflictPanel projectId={projectId} conflicts={mergeConflicts || []} resolutions={mergeResolutions || []} onClose={() => handleTabClose('merge-conflicts')} onMergeComplete={() => { setMergeConflicts?.([]); setMergeResolutions?.([]); handleTabClose('merge-conflicts'); }} onAbort={() => { setMergeConflicts?.([]); setMergeResolutions?.([]); handleTabClose('merge-conflicts'); }} onResolutionChange={(updated: any) => setMergeResolutions?.(updated)} /></Suspense>;
     if (currentTab.id === 'monitoring') return <Suspense fallback={<ECodeLoading size="md" />}><MonitoringPanel projectId={projectId} onClose={() => handleTabClose('monitoring')} /></Suspense>;
     if (currentTab.id === 'networking') return <Suspense fallback={<ECodeLoading size="md" />}><NetworkingPanel projectId={projectId} onClose={() => handleTabClose('networking')} /></Suspense>;

--- a/client/src/components/mcp/GitHubMCPPanel.tsx
+++ b/client/src/components/mcp/GitHubMCPPanel.tsx
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -11,158 +10,136 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { 
-  Github, 
-  GitBranch, 
-  GitPullRequest, 
-  GitCommit,
+import {
+  Github,
+  GitPullRequest,
   Plus,
   Loader2,
   ExternalLink,
   Star,
-  Eye,
   GitFork,
   AlertCircle,
-  CheckCircle
+  CheckCircle,
 } from 'lucide-react';
 
 interface Repository {
-  id: string;
+  id: number;
   name: string;
-  description: string;
+  fullName?: string;
+  description: string | null;
   url: string;
   private: boolean;
   stars: number;
   forks: number;
-  language: string;
-  updatedAt: string;
+  language: string | null;
+  updatedAt: string | null;
 }
 
-export function GitHubMCPPanel({ projectId }: { projectId?: number }) {
+export function GitHubMCPPanel({ projectId: _projectId }: { projectId?: number }) {
   const [activeTab, setActiveTab] = useState('repositories');
   const [searchQuery, setSearchQuery] = useState('');
   const { toast } = useToast();
 
-  // Query for repositories
-  const { data: repos, isLoading: reposLoading, refetch: refetchRepos } = useQuery<Repository[]>({
+  const {
+    data: repos,
+    isLoading: reposLoading,
+    isError: reposError,
+    refetch: refetchRepos,
+  } = useQuery<Repository[]>({
     queryKey: ['/api/mcp/github/repositories'],
-    queryFn: async () => {
-      const response = await apiRequest('GET', '/api/mcp/github/repositories');
-      if (!response.ok) throw new Error('Failed to fetch repositories');
-      return response.json();
-    },
+    queryFn: () => apiRequest<Repository[]>('GET', '/api/mcp/github/repositories'),
     retry: false,
-    onSuccess: (data) => {
-      if (data && data.length > 0 && !newPR.repo) {
-        setNewPR(prev => ({
-          ...prev,
-          repo: data[0].name
-        }));
-      }
-    }
   });
 
-  // Create repository mutation
-  const createRepoMutation = useMutation({
-    mutationFn: async (data: { name: string; description: string; isPrivate: boolean }) => {
-      const response = await apiRequest('POST', '/api/mcp/github/repositories', data);
-      if (!response.ok) throw new Error('Failed to create repository');
-      return response.json();
-    },
+  const createRepoMutation = useMutation<
+    Repository,
+    Error,
+    { name: string; description: string; isPrivate: boolean }
+  >({
+    mutationFn: (data) => apiRequest<Repository>('POST', '/api/mcp/github/repositories', data),
     onSuccess: (data) => {
       toast({
         title: 'Repository Created',
-        description: `Successfully created ${data.name}`
+        description: `Successfully created ${data.name}`,
       });
       refetchRepos();
     },
     onError: (error) => {
-      toast({
-        title: 'Error',
-        description: error.message,
-        variant: 'destructive'
-      });
-    }
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    },
   });
 
-  // Create issue mutation
-  const createIssueMutation = useMutation({
-    mutationFn: async (data: { repo: string; title: string; body: string; labels: string[] }) => {
-      const response = await apiRequest('POST', '/api/mcp/github/issues', data);
-      if (!response.ok) throw new Error('Failed to create issue');
-      return response.json();
-    },
+  const createIssueMutation = useMutation<
+    { number: number },
+    Error,
+    { repo: string; title: string; body: string; labels: string[] }
+  >({
+    mutationFn: (data) => apiRequest<{ number: number }>('POST', '/api/mcp/github/issues', data),
     onSuccess: (data) => {
       toast({
         title: 'Issue Created',
-        description: `Issue #${data.number} created successfully`
+        description: `Issue #${data.number} created successfully`,
       });
     },
     onError: (error) => {
-      toast({
-        title: 'Error',
-        description: error.message,
-        variant: 'destructive'
-      });
-    }
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    },
   });
 
-  // Create pull request mutation
-  const createPRMutation = useMutation({
-    mutationFn: async (data: { repo: string; title: string; body: string; head: string; base: string }) => {
-      const response = await apiRequest('POST', '/api/mcp/github/pull-requests', data);
-      if (!response.ok) throw new Error('Failed to create pull request');
-      return response.json();
-    },
+  const createPRMutation = useMutation<
+    { number: number },
+    Error,
+    { repo: string; title: string; body: string; head: string; base: string }
+  >({
+    mutationFn: (data) => apiRequest<{ number: number }>('POST', '/api/mcp/github/pull-requests', data),
     onSuccess: (data) => {
       toast({
         title: 'Pull Request Created',
-        description: `PR #${data.number} created successfully`
+        description: `PR #${data.number} created successfully`,
       });
     },
     onError: (error) => {
-      toast({
-        title: 'Error',
-        description: error.message,
-        variant: 'destructive'
-      });
-    }
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    },
   });
 
-  const [newRepo, setNewRepo] = useState({
-    name: '',
-    description: '',
-    isPrivate: false
-  });
-
-  const [newIssue, setNewIssue] = useState({
-    repo: '',
-    title: '',
-    body: '',
-    labels: ''
-  });
-
+  const [newRepo, setNewRepo] = useState({ name: '', description: '', isPrivate: false });
+  const [newIssue, setNewIssue] = useState({ repo: '', title: '', body: '', labels: '' });
   const [newPR, setNewPR] = useState({
     repo: '',
     title: 'Merge changes to main',
     body: 'This PR merges the latest changes into the main branch.',
     head: 'develop',
-    base: 'main'
+    base: 'main',
   });
 
-  // Auto-fill repo when repos load
   useEffect(() => {
     if (repos && repos.length > 0 && !newPR.repo) {
-      setNewPR(prev => ({
-        ...prev,
-        repo: repos[0].name
-      }));
+      setNewPR((prev) => ({ ...prev, repo: repos[0].fullName || repos[0].name }));
     }
   }, [repos, newPR.repo]);
 
-  const filteredRepos = repos?.filter(repo => 
-    repo.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    repo.description?.toLowerCase().includes(searchQuery.toLowerCase())
+  const filteredRepos = repos?.filter(
+    (repo) =>
+      repo.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      (repo.description?.toLowerCase().includes(searchQuery.toLowerCase()) ?? false),
+  );
+
+  const statusBadge = reposError ? (
+    <Badge variant="outline" className="bg-red-500/10 text-red-500 border-red-500/30">
+      <AlertCircle className="w-3 h-3 mr-1" />
+      Not connected
+    </Badge>
+  ) : reposLoading ? (
+    <Badge variant="outline" className="bg-amber-500/10 text-amber-500 border-amber-500/30">
+      <Loader2 className="w-3 h-3 mr-1 animate-spin" />
+      Connecting
+    </Badge>
+  ) : (
+    <Badge variant="outline" className="bg-green-500/10 text-green-500 border-green-500/30">
+      <CheckCircle className="w-3 h-3 mr-1" />
+      Connected
+    </Badge>
   );
 
   return (
@@ -173,10 +150,7 @@ export function GitHubMCPPanel({ projectId }: { projectId?: number }) {
             <Github className="w-5 h-5 text-[var(--ecode-accent)]" />
             <CardTitle className="text-[var(--ecode-text)]">GitHub Integration</CardTitle>
           </div>
-          <Badge variant="outline" className="bg-green-500/10 text-green-500 border-green-500/30">
-            <CheckCircle className="w-3 h-3 mr-1" />
-            Connected
-          </Badge>
+          {statusBadge}
         </div>
         <CardDescription className="text-[var(--ecode-muted)]">
           Manage repositories, issues, and pull requests directly from E-Code
@@ -205,27 +179,42 @@ export function GitHubMCPPanel({ projectId }: { projectId?: number }) {
                 <div className="flex items-center justify-center py-8">
                   <Loader2 className="w-6 h-6 animate-spin text-[var(--ecode-muted)]" />
                 </div>
-              ) : filteredRepos?.length === 0 ? (
+              ) : reposError ? (
+                <div className="text-center py-8 text-[var(--ecode-muted)]">
+                  <AlertCircle className="w-12 h-12 mx-auto mb-2 opacity-50" />
+                  <p>GitHub not connected</p>
+                  <p className="text-[13px] mt-1">
+                    Connect GitHub via Settings to see your repositories.
+                  </p>
+                </div>
+              ) : !filteredRepos || filteredRepos.length === 0 ? (
                 <div className="text-center py-8 text-[var(--ecode-muted)]">
                   <Github className="w-12 h-12 mx-auto mb-2 opacity-50" />
                   <p>No repositories found</p>
                 </div>
               ) : (
                 <div className="space-y-2">
-                  {filteredRepos?.map((repo) => (
+                  {filteredRepos.map((repo) => (
                     <div
                       key={repo.id}
                       className="p-3 rounded-lg bg-[var(--ecode-sidebar)] hover:bg-[var(--ecode-sidebar-hover)] transition-colors"
+                      data-testid={`mcp-github-repo-${repo.name}`}
                     >
                       <div className="flex items-start justify-between">
                         <div className="flex-1">
                           <div className="flex items-center gap-2 mb-1">
                             <h4 className="font-medium text-[var(--ecode-text)]">{repo.name}</h4>
                             {repo.private && (
-                              <Badge variant="outline" className="text-[11px]">Private</Badge>
+                              <Badge variant="outline" className="text-[11px]">
+                                Private
+                              </Badge>
                             )}
                           </div>
-                          <p className="text-[13px] text-[var(--ecode-muted)] mb-2">{repo.description}</p>
+                          {repo.description && (
+                            <p className="text-[13px] text-[var(--ecode-muted)] mb-2">
+                              {repo.description}
+                            </p>
+                          )}
                           <div className="flex items-center gap-4 text-[11px] text-[var(--ecode-muted)]">
                             {repo.language && (
                               <span className="flex items-center gap-1">
@@ -246,7 +235,7 @@ export function GitHubMCPPanel({ projectId }: { projectId?: number }) {
                         <Button
                           variant="ghost"
                           size="sm"
-                          onClick={() => window.open(repo.url, '_blank')}
+                          onClick={() => window.open(repo.url, '_blank', 'noopener,noreferrer')}
                         >
                           <ExternalLink className="w-4 h-4" />
                         </Button>
@@ -293,6 +282,7 @@ export function GitHubMCPPanel({ projectId }: { projectId?: number }) {
                 onClick={() => createRepoMutation.mutate(newRepo)}
                 disabled={!newRepo.name || createRepoMutation.isPending}
                 className="w-full"
+                data-testid="mcp-github-create-repo"
               >
                 {createRepoMutation.isPending ? (
                   <Loader2 className="w-4 h-4 mr-2 animate-spin" />
@@ -347,10 +337,15 @@ export function GitHubMCPPanel({ projectId }: { projectId?: number }) {
                 />
               </div>
               <Button
-                onClick={() => createIssueMutation.mutate({
-                  ...newIssue,
-                  labels: newIssue.labels.split(',').map(l => l.trim()).filter(Boolean)
-                })}
+                onClick={() =>
+                  createIssueMutation.mutate({
+                    ...newIssue,
+                    labels: newIssue.labels
+                      .split(',')
+                      .map((l) => l.trim())
+                      .filter(Boolean),
+                  })
+                }
                 disabled={!newIssue.repo || !newIssue.title || createIssueMutation.isPending}
                 className="w-full"
               >
@@ -420,7 +415,9 @@ export function GitHubMCPPanel({ projectId }: { projectId?: number }) {
               </div>
               <Button
                 onClick={() => createPRMutation.mutate(newPR)}
-                disabled={!newPR.repo || !newPR.title || !newPR.head || createPRMutation.isPending}
+                disabled={
+                  !newPR.repo || !newPR.title || !newPR.head || createPRMutation.isPending
+                }
                 className="w-full"
               >
                 {createPRMutation.isPending ? (

--- a/client/src/components/mcp/MemoryMCPPanel.tsx
+++ b/client/src/components/mcp/MemoryMCPPanel.tsx
@@ -49,74 +49,48 @@ export function MemoryMCPPanel({ projectId }: { projectId?: number }) {
   const [selectedNode, setSelectedNode] = useState<MemoryNode | null>(null);
   const { toast } = useToast();
 
-  // Search memory mutation
   const searchMemoryMutation = useMutation<MemoryNode[], Error, string>({
-    mutationFn: async (query: string) => {
-      const response = await apiRequest('POST', '/api/mcp/memory/search', { query });
-      if (!response.ok) throw new Error('Search failed');
-      return response.json();
-    },
+    mutationFn: (query: string) =>
+      apiRequest<MemoryNode[]>('POST', '/api/mcp/memory/search', { query }),
     onError: (error) => {
-      toast({
-        title: 'Search Failed',
-        description: error.message,
-        variant: 'destructive'
-      });
-    }
+      toast({ title: 'Search Failed', description: error.message, variant: 'destructive' });
+    },
   });
 
-  // Get conversation history
   const { data: conversations, isLoading: conversationsLoading } = useQuery<Conversation[]>({
     queryKey: ['/api/mcp/memory/conversations'],
-    queryFn: async () => {
-      const response = await apiRequest('GET', '/api/mcp/memory/conversations');
-      if (!response.ok) throw new Error('Failed to fetch conversations');
-      return response.json();
-    }
+    queryFn: () => apiRequest<Conversation[]>('GET', '/api/mcp/memory/conversations'),
   });
 
-  // Create memory node mutation
-  const createNodeMutation = useMutation({
-    mutationFn: async (data: { type: string; content: string; metadata: Record<string, any> }) => {
-      const response = await apiRequest('POST', '/api/mcp/memory/nodes', data);
-      if (!response.ok) throw new Error('Failed to create memory node');
-      return response.json();
-    },
-    onSuccess: (data) => {
-      toast({
-        title: 'Memory Created',
-        description: 'New memory node has been added to the knowledge graph'
-      });
-    },
-    onError: (error) => {
-      toast({
-        title: 'Error',
-        description: error.message,
-        variant: 'destructive'
-      });
-    }
-  });
-
-  // Create edge between nodes
-  const createEdgeMutation = useMutation({
-    mutationFn: async (data: { fromId: string; toId: string; relationship: string }) => {
-      const response = await apiRequest('POST', '/api/mcp/memory/edges', data);
-      if (!response.ok) throw new Error('Failed to create connection');
-      return response.json();
-    },
+  const createNodeMutation = useMutation<
+    MemoryNode,
+    Error,
+    { type: string; content: string; metadata: Record<string, any> }
+  >({
+    mutationFn: (data) => apiRequest<MemoryNode>('POST', '/api/mcp/memory/nodes', data),
     onSuccess: () => {
       toast({
-        title: 'Connection Created',
-        description: 'Memory nodes have been linked'
+        title: 'Memory Created',
+        description: 'New memory node has been added to the knowledge graph',
       });
     },
     onError: (error) => {
-      toast({
-        title: 'Error',
-        description: error.message,
-        variant: 'destructive'
-      });
-    }
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const createEdgeMutation = useMutation<
+    { id: string },
+    Error,
+    { fromId: string; toId: string; relationship: string }
+  >({
+    mutationFn: (data) => apiRequest<{ id: string }>('POST', '/api/mcp/memory/edges', data),
+    onSuccess: () => {
+      toast({ title: 'Connection Created', description: 'Memory nodes have been linked' });
+    },
+    onError: (error) => {
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    },
   });
 
   const [newNode, setNewNode] = useState({

--- a/client/src/components/mcp/PostgreSQLMCPPanel.tsx
+++ b/client/src/components/mcp/PostgreSQLMCPPanel.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -11,21 +10,19 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { 
-  Database, 
+import {
+  Database,
   Table as TableIcon,
   Play,
   Download,
   RefreshCw,
   Loader2,
-  AlertTriangle,
   CheckCircle,
-  Code,
+  AlertCircle,
   Eye,
   Columns,
-  Key
+  Key,
 } from 'lucide-react';
-import { LightSyntaxHighlighter, darkStyle } from '@/components/ui/LightSyntaxHighlighter';
 
 interface DatabaseTable {
   name: string;
@@ -49,61 +46,53 @@ interface QueryResult {
   executionTime: number;
 }
 
-export function PostgreSQLMCPPanel({ projectId }: { projectId?: number }) {
+export function PostgreSQLMCPPanel({ projectId: _projectId }: { projectId?: number }) {
   const [activeTab, setActiveTab] = useState('tables');
   const [selectedTable, setSelectedTable] = useState<string | null>(null);
   const [sqlQuery, setSqlQuery] = useState('');
   const [queryHistory, setQueryHistory] = useState<string[]>([]);
   const { toast } = useToast();
 
-  // Load from localStorage on mount
   useEffect(() => {
     const savedHistory = localStorage.getItem('sql-query-history');
     if (savedHistory) {
-      setQueryHistory(JSON.parse(savedHistory));
+      try {
+        setQueryHistory(JSON.parse(savedHistory));
+      } catch {
+        // ignore invalid history
+      }
     }
   }, []);
 
-  // Query for database tables
-  const { data: tables, isLoading: tablesLoading, refetch: refetchTables } = useQuery<DatabaseTable[]>({
+  const {
+    data: tables,
+    isLoading: tablesLoading,
+    isError: tablesError,
+    refetch: refetchTables,
+  } = useQuery<DatabaseTable[]>({
     queryKey: ['/api/mcp/postgres/tables'],
-    queryFn: async () => {
-      const response = await apiRequest('GET', '/api/mcp/postgres/tables');
-      if (!response.ok) throw new Error('Failed to fetch tables');
-      return response.json();
-    }
+    queryFn: () => apiRequest<DatabaseTable[]>('GET', '/api/mcp/postgres/tables'),
   });
 
-  // Query for selected table schema
   const { data: tableSchema, isLoading: schemaLoading } = useQuery<TableSchema[]>({
     queryKey: ['/api/mcp/postgres/schema', selectedTable],
-    queryFn: async () => {
-      if (!selectedTable) return [];
-      const response = await apiRequest('GET', `/api/mcp/postgres/schema/${selectedTable}`);
-      if (!response.ok) throw new Error('Failed to fetch table schema');
-      return response.json();
-    },
-    enabled: !!selectedTable
+    queryFn: () =>
+      apiRequest<TableSchema[]>(
+        'GET',
+        `/api/mcp/postgres/schema/${encodeURIComponent(selectedTable || '')}`,
+      ),
+    enabled: !!selectedTable,
   });
 
-  // Execute query mutation
   const executeQueryMutation = useMutation<QueryResult, Error, string>({
-    mutationFn: async (query: string) => {
-      const response = await apiRequest('POST', '/api/mcp/postgres/query', { query });
-      if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.message || 'Query execution failed');
-      }
-      return response.json();
-    },
+    mutationFn: (query: string) =>
+      apiRequest<QueryResult>('POST', '/api/mcp/postgres/query', { query }),
     onSuccess: (data, query) => {
       toast({
         title: 'Query Executed',
-        description: `${data.rowCount} rows affected in ${data.executionTime}ms`
+        description: `${data.rowCount} rows affected in ${data.executionTime}ms`,
       });
-      
-      // Add to history
-      const newHistory = [query, ...queryHistory.filter(q => q !== query)].slice(0, 10);
+      const newHistory = [query, ...queryHistory.filter((q) => q !== query)].slice(0, 10);
       setQueryHistory(newHistory);
       localStorage.setItem('sql-query-history', JSON.stringify(newHistory));
     },
@@ -111,34 +100,45 @@ export function PostgreSQLMCPPanel({ projectId }: { projectId?: number }) {
       toast({
         title: 'Query Failed',
         description: error.message,
-        variant: 'destructive'
+        variant: 'destructive',
       });
-    }
+    },
   });
 
-  // Backup database mutation
-  const backupMutation = useMutation({
-    mutationFn: async () => {
-      const response = await apiRequest('POST', '/api/mcp/postgres/backup');
-      if (!response.ok) throw new Error('Backup failed');
-      return response.json();
-    },
+  const backupMutation = useMutation<{ filename: string }, Error, void>({
+    mutationFn: () => apiRequest<{ filename: string }>('POST', '/api/mcp/postgres/backup'),
     onSuccess: (data) => {
       toast({
         title: 'Backup Created',
-        description: `Database backed up successfully: ${data.filename}`
+        description: `Database backed up successfully: ${data.filename}`,
       });
     },
     onError: (error) => {
       toast({
         title: 'Backup Failed',
         description: error.message,
-        variant: 'destructive'
+        variant: 'destructive',
       });
-    }
+    },
   });
 
   const queryResult = executeQueryMutation.data;
+  const statusBadge = tablesError ? (
+    <Badge variant="outline" className="bg-red-500/10 text-red-500 border-red-500/30">
+      <AlertCircle className="w-3 h-3 mr-1" />
+      Disconnected
+    </Badge>
+  ) : tablesLoading ? (
+    <Badge variant="outline" className="bg-amber-500/10 text-amber-500 border-amber-500/30">
+      <Loader2 className="w-3 h-3 mr-1 animate-spin" />
+      Connecting
+    </Badge>
+  ) : (
+    <Badge variant="outline" className="bg-green-500/10 text-green-500 border-green-500/30">
+      <CheckCircle className="w-3 h-3 mr-1" />
+      Connected
+    </Badge>
+  );
 
   return (
     <Card className="h-full bg-[var(--ecode-bg)] border-[var(--ecode-border)]">
@@ -149,15 +149,13 @@ export function PostgreSQLMCPPanel({ projectId }: { projectId?: number }) {
             <CardTitle className="text-[var(--ecode-text)]">PostgreSQL Database</CardTitle>
           </div>
           <div className="flex items-center gap-2">
-            <Badge variant="outline" className="bg-green-500/10 text-green-500 border-green-500/30">
-              <CheckCircle className="w-3 h-3 mr-1" />
-              Connected
-            </Badge>
+            {statusBadge}
             <Button
               variant="outline"
               size="sm"
               onClick={() => backupMutation.mutate()}
               disabled={backupMutation.isPending}
+              data-testid="mcp-postgres-backup"
             >
               {backupMutation.isPending ? (
                 <Loader2 className="w-4 h-4 animate-spin" />
@@ -183,11 +181,7 @@ export function PostgreSQLMCPPanel({ projectId }: { projectId?: number }) {
           <TabsContent value="tables" className="space-y-4">
             <div className="flex items-center justify-between mb-2">
               <h3 className="text-[13px] font-medium text-[var(--ecode-text)]">Database Tables</h3>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => refetchTables()}
-              >
+              <Button variant="ghost" size="sm" onClick={() => refetchTables()}>
                 <RefreshCw className="w-4 h-4" />
               </Button>
             </div>
@@ -199,22 +193,28 @@ export function PostgreSQLMCPPanel({ projectId }: { projectId?: number }) {
                     <div className="flex items-center justify-center py-8">
                       <Loader2 className="w-6 h-6 animate-spin text-[var(--ecode-muted)]" />
                     </div>
-                  ) : tables?.length === 0 ? (
+                  ) : tablesError ? (
+                    <div className="text-center py-8 text-[var(--ecode-muted)]">
+                      <AlertCircle className="w-12 h-12 mx-auto mb-2 opacity-50" />
+                      <p>Could not load tables</p>
+                    </div>
+                  ) : !tables || tables.length === 0 ? (
                     <div className="text-center py-8 text-[var(--ecode-muted)]">
                       <Database className="w-12 h-12 mx-auto mb-2 opacity-50" />
                       <p>No tables found</p>
                     </div>
                   ) : (
                     <div className="p-2">
-                      {tables?.map((table) => (
+                      {tables.map((table) => (
                         <div
-                          key={table.name}
+                          key={`${table.schema}.${table.name}`}
                           onClick={() => setSelectedTable(table.name)}
                           className={`p-3 rounded-lg mb-2 cursor-pointer transition-colors ${
                             selectedTable === table.name
                               ? 'bg-[var(--ecode-accent)]/10 border border-[var(--ecode-accent)]'
                               : 'hover:bg-[var(--ecode-sidebar-hover)]'
                           }`}
+                          data-testid={`mcp-postgres-table-${table.name}`}
                         >
                           <div className="flex items-center justify-between">
                             <div className="flex items-center gap-2">
@@ -269,7 +269,10 @@ export function PostgreSQLMCPPanel({ projectId }: { projectId?: number }) {
                                   {col.type}
                                 </TableCell>
                                 <TableCell>
-                                  <Badge variant={col.nullable ? 'outline' : 'default'} className="text-[11px]">
+                                  <Badge
+                                    variant={col.nullable ? 'outline' : 'default'}
+                                    className="text-[11px]"
+                                  >
                                     {col.nullable ? 'Yes' : 'No'}
                                   </Badge>
                                 </TableCell>
@@ -301,6 +304,7 @@ export function PostgreSQLMCPPanel({ projectId }: { projectId?: number }) {
               <Button
                 onClick={() => executeQueryMutation.mutate(sqlQuery)}
                 disabled={!sqlQuery.trim() || executeQueryMutation.isPending}
+                data-testid="mcp-postgres-execute"
               >
                 {executeQueryMutation.isPending ? (
                   <Loader2 className="w-4 h-4 mr-2 animate-spin" />
@@ -313,7 +317,7 @@ export function PostgreSQLMCPPanel({ projectId }: { projectId?: number }) {
               <Button
                 variant="outline"
                 onClick={() => {
-                  const viewQuery = selectedTable 
+                  const viewQuery = selectedTable
                     ? `SELECT * FROM ${selectedTable} LIMIT 100;`
                     : 'SELECT * FROM  LIMIT 100;';
                   setSqlQuery(viewQuery);

--- a/client/src/components/mobile/ReplitMobileNavigation.tsx
+++ b/client/src/components/mobile/ReplitMobileNavigation.tsx
@@ -33,7 +33,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-export type MobileTab = 'preview' | 'agent' | 'deploy' | 'more' | 'files' | 'search' | 'git' | 'packages' | 'secrets' | 'database' | 'terminal' | 'settings' | 'history' | 'extensions' | 'workflows' | 'debug' | 'checkpoints' | 'security' | 'collaboration' | 'actions' | 'tools' | 'shell' | 'storage' | 'themes' | 'multiplayers' | 'testing';
+export type MobileTab = 'preview' | 'agent' | 'deploy' | 'more' | 'files' | 'search' | 'git' | 'packages' | 'secrets' | 'database' | 'terminal' | 'settings' | 'history' | 'extensions' | 'workflows' | 'debug' | 'checkpoints' | 'security' | 'collaboration' | 'actions' | 'tools' | 'shell' | 'storage' | 'themes' | 'multiplayers' | 'testing' | 'mcp-suite';
 
 export interface OpenTab {
   id: string;

--- a/client/src/hooks/useIDEWorkspace.ts
+++ b/client/src/hooks/useIDEWorkspace.ts
@@ -172,6 +172,7 @@ export const availableTools: AvailableTool[] = [
   { id: 'multiplayers', label: 'Multiplayer', icon: '👥' },
   { id: 'deploy', label: 'Deploy', icon: '🚀' },
   { id: 'preview', label: 'Preview', icon: '👁️' },
+  { id: 'mcp-suite', label: 'MCP Suite', icon: '🧠' },
 ];
 
 export function useIDEWorkspace(projectId: string) {

--- a/server/mcp/api/github.ts
+++ b/server/mcp/api/github.ts
@@ -1,42 +1,105 @@
-// @ts-nocheck
-import { Router } from 'express';
-import fetch from 'node-fetch';
+import { Router, Request, Response, NextFunction } from 'express';
+import fetch, { type RequestInit } from 'node-fetch';
 import { ensureAuthenticated } from '../../middleware/auth';
 import { githubOAuth } from '../../services/github-oauth';
 import { storage } from '../../storage';
 
 const router = Router();
 
+interface GithubRequestContext extends Request {
+  githubToken?: string;
+}
+
 const mapRepository = (repo: any) => ({
   id: repo.id,
   name: repo.name,
-  fullName: repo.full_name ?? repo.fullName ?? (repo.owner?.login ? `${repo.owner.login}/${repo.name}` : repo.name),
+  fullName: repo.full_name ?? (repo.owner?.login ? `${repo.owner.login}/${repo.name}` : repo.name),
   description: repo.description ?? null,
-  url: repo.html_url ?? repo.url ?? null,
+  url: repo.html_url ?? null,
   sshUrl: repo.ssh_url ?? null,
   cloneUrl: repo.clone_url ?? null,
   private: Boolean(repo.private),
-  stars: repo.stargazers_count ?? repo.stars ?? 0,
-  forks: repo.forks_count ?? repo.forks ?? 0,
-  watchers: repo.watchers_count ?? repo.watchers ?? 0,
+  stars: repo.stargazers_count ?? 0,
+  forks: repo.forks_count ?? 0,
+  watchers: repo.watchers_count ?? 0,
   language: repo.language ?? null,
-  updatedAt: repo.updated_at ?? repo.updatedAt ?? null,
-  defaultBranch: repo.default_branch ?? repo.defaultBranch ?? 'main',
-  owner: repo.owner?.login ?? repo.owner ?? null,
+  updatedAt: repo.updated_at ?? null,
+  defaultBranch: repo.default_branch ?? 'main',
+  owner: repo.owner?.login ?? null,
 });
 
-const resolveRepoCoordinates = async (userId: number, repo: string) => {
-  const storedToken = await storage.getGitHubToken(userId);
-  const [ownerPart, repoPart] = repo.includes('/') ? repo.split('/') : [storedToken?.githubUsername, repo];
+const mapIssue = (issue: any) => ({
+  number: issue.number,
+  title: issue.title,
+  body: issue.body ?? '',
+  labels: (issue.labels ?? [])
+    .map((label: any) => (typeof label === 'string' ? label : label?.name))
+    .filter(Boolean),
+  state: issue.state,
+  url: issue.html_url,
+  createdAt: issue.created_at,
+  updatedAt: issue.updated_at,
+  author: issue.user?.login ?? null,
+  repository: issue.repository_url?.split('/').slice(-2).join('/') ?? null,
+});
 
-  if (!ownerPart || !repoPart) {
-    return null;
+const mapPullRequest = (pr: any) => ({
+  number: pr.number,
+  title: pr.title,
+  body: pr.body ?? '',
+  state: pr.state,
+  url: pr.html_url,
+  head: pr.head?.ref ?? null,
+  base: pr.base?.ref ?? null,
+  createdAt: pr.created_at,
+  updatedAt: pr.updated_at,
+  mergedAt: pr.merged_at ?? null,
+  author: pr.user?.login ?? null,
+});
+
+const requireGithubToken = async (
+  req: GithubRequestContext,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (!req.user?.id) {
+    return res.status(401).json({ error: 'Not authenticated' });
   }
-
-  return { owner: ownerPart, repo: repoPart };
+  try {
+    const token = await githubOAuth.getUserToken(req.user.id);
+    if (!token) {
+      return res.status(401).json({
+        error: 'GitHub not connected',
+        requiresAuth: true,
+      });
+    }
+    req.githubToken = token;
+    next();
+  } catch (error: any) {
+    res.status(500).json({ error: 'Failed to resolve GitHub token', message: error.message });
+  }
 };
 
-const githubRequest = async (token: string, url: string, options: RequestInit) => {
+const resolveRepoCoordinates = async (userId: number, repo: string) => {
+  if (repo.includes('/')) {
+    const [owner, name] = repo.split('/');
+    return { owner, repo: name };
+  }
+  const user = await storage.getUser(String(userId));
+  if (!user?.githubUsername) return null;
+  return { owner: user.githubUsername, repo };
+};
+
+interface GithubResult<T> {
+  data?: T;
+  error?: { status: number; message: string };
+}
+
+const githubRequest = async <T = any>(
+  token: string,
+  url: string,
+  options: RequestInit = {},
+): Promise<GithubResult<T>> => {
   const response = await fetch(url, {
     ...options,
     headers: {
@@ -48,28 +111,27 @@ const githubRequest = async (token: string, url: string, options: RequestInit) =
   });
 
   if (!response.ok) {
-    const errorBody = await response.json().catch(() => ({}));
-    const message = errorBody?.message || 'GitHub request failed';
-    return { error: { status: response.status, message } };
+    const errorBody = await response.json().catch(() => ({})) as any;
+    return {
+      error: {
+        status: response.status,
+        message: errorBody?.message || 'GitHub request failed',
+      },
+    };
   }
 
-  return { data: await response.json() };
+  return { data: (await response.json()) as T };
 };
 
+router.use(ensureAuthenticated);
+
 // Get user repositories
-router.get('/repositories', ensureAuthenticated, async (req, res) => {
+router.get('/repositories', requireGithubToken, async (req: GithubRequestContext, res) => {
   try {
     const page = Math.max(parseInt(req.query.page as string, 10) || 1, 1);
     const perPage = Math.min(Math.max(parseInt(req.query.perPage as string, 10) || 30, 1), 100);
 
-    if (error) {
-      return res.status(error.status).json({
-        error: 'GitHub not connected',
-        message: error.message,
-      });
-    }
-
-    const repos = await githubOAuth.getUserRepos(req.githubToken, page, perPage);
+    const repos = await githubOAuth.getUserRepos(req.githubToken!, page, perPage);
     res.json(repos.map(mapRepository));
   } catch (error: any) {
     console.error('GitHub MCP repositories error:', error);
@@ -81,47 +143,14 @@ router.get('/repositories', ensureAuthenticated, async (req, res) => {
 });
 
 // Create repository
-router.post('/repositories', ensureAuthenticated, async (req, res) => {
+router.post('/repositories', requireGithubToken, async (req: GithubRequestContext, res) => {
   try {
     const { name, description, isPrivate } = req.body ?? {};
-
     if (!name || typeof name !== 'string') {
-      return res.status(400).json({
-        error: 'Repository name is required',
-        message: 'Please provide a valid repository name.',
-      });
+      return res.status(400).json({ error: 'Repository name is required' });
     }
 
-    const { octokit, error } = await createGitHubClient(req.user!.id);
-
-    if (error) {
-      return res.status(error.status).json({
-        error: 'GitHub not connected',
-        message: error.message,
-      });
-    }
-
-    const { data } = await octokit.repos.createForAuthenticatedUser({
-      name,
-      description,
-      private: Boolean(isPrivate),
-      auto_init: true,
-    });
-
-    res.status(201).json({
-      id: data.id,
-      name: data.name,
-      description: data.description,
-      url: data.html_url,
-      private: data.private,
-      stars: data.stargazers_count,
-      forks: data.forks_count,
-      language: data.language,
-      updatedAt: data.updated_at,
-      defaultBranch: data.default_branch,
-      owner: data.owner?.login,
-    });
-    const result = await githubRequest(req.githubToken, 'https://api.github.com/user/repos', {
+    const result = await githubRequest<any>(req.githubToken!, 'https://api.github.com/user/repos', {
       method: 'POST',
       body: JSON.stringify({
         name,
@@ -138,43 +167,70 @@ router.post('/repositories', ensureAuthenticated, async (req, res) => {
     res.status(201).json(mapRepository(result.data));
   } catch (error: any) {
     console.error('GitHub MCP create repository error:', error);
-    res.status(500).json({
-      error: 'Failed to create repository',
-      message: error.message,
-    });
+    res.status(500).json({ error: 'Failed to create repository', message: error.message });
+  }
+});
+
+// List issues — either for a specific repo or searched across the user
+router.get('/issues', requireGithubToken, async (req: GithubRequestContext, res) => {
+  try {
+    const repoParam = typeof req.query.repo === 'string' ? req.query.repo : undefined;
+    const state = (req.query.state as string) || 'open';
+    const q = (req.query.q as string) || '';
+
+    let url: string;
+    if (repoParam) {
+      const coords = await resolveRepoCoordinates(req.user!.id, repoParam);
+      if (!coords) {
+        return res.status(400).json({ error: 'Unable to resolve repository' });
+      }
+      const params = new URLSearchParams({ state, per_page: '50' });
+      url = `https://api.github.com/repos/${coords.owner}/${coords.repo}/issues?${params.toString()}`;
+    } else {
+      const params = new URLSearchParams({
+        q: `${q} is:issue state:${state} involves:@me`.trim(),
+        per_page: '50',
+      });
+      url = `https://api.github.com/search/issues?${params.toString()}`;
+    }
+
+    const result = await githubRequest<any>(req.githubToken!, url, { method: 'GET' });
+    if (result.error) {
+      return res.status(result.error.status).json({ error: result.error.message });
+    }
+
+    const items = Array.isArray(result.data) ? result.data : result.data?.items ?? [];
+    // Filter out pull requests when hitting /repos/.../issues (GitHub returns both)
+    const issues = items.filter((item: any) => !item.pull_request).map(mapIssue);
+    res.json(issues);
+  } catch (error: any) {
+    console.error('GitHub MCP list issues error:', error);
+    res.status(500).json({ error: 'Failed to fetch issues', message: error.message });
   }
 });
 
 // Create issue
-router.post('/issues', ensureAuthenticated, async (req, res) => {
+router.post('/issues', requireGithubToken, async (req: GithubRequestContext, res) => {
   try {
     const { repo, title, body, labels } = req.body ?? {};
-
     if (!repo || typeof repo !== 'string') {
-      return res.status(400).json({
-        error: 'Repository is required',
-        message: 'Please provide the repository to create an issue in.',
-      });
+      return res.status(400).json({ error: 'Repository is required' });
     }
-
     if (!title || typeof title !== 'string') {
-      return res.status(400).json({
-        error: 'Issue title is required',
-        message: 'Please provide a valid issue title.',
-      });
+      return res.status(400).json({ error: 'Issue title is required' });
     }
 
-    const coordinates = await resolveRepoCoordinates(req.user!.id, repo);
-    if (!coordinates) {
+    const coords = await resolveRepoCoordinates(req.user!.id, repo);
+    if (!coords) {
       return res.status(400).json({
         error: 'Unable to resolve repository owner',
         message: 'Connect GitHub or provide the repository as "owner/name".',
       });
     }
 
-    const issueResult = await githubRequest(
-      req.githubToken,
-      `https://api.github.com/repos/${coordinates.owner}/${coordinates.repo}/issues`,
+    const result = await githubRequest<any>(
+      req.githubToken!,
+      `https://api.github.com/repos/${coords.owner}/${coords.repo}/issues`,
       {
         method: 'POST',
         body: JSON.stringify({
@@ -182,107 +238,85 @@ router.post('/issues', ensureAuthenticated, async (req, res) => {
           body,
           labels: Array.isArray(labels) ? labels : undefined,
         }),
-      }
-    );
-
-    if (issueResult.error) {
-      return res.status(issueResult.error.status).json({ error: issueResult.error.message });
-    }
-
-    const issue = issueResult.data;
-    res.status(201).json({
-      number: issue.number,
-      title: issue.title,
-      body: issue.body,
-      labels: (issue.labels ?? [])
-        .map((label: any) => (typeof label === 'string' ? label : label?.name))
-        .filter(Boolean),
-      state: issue.state,
-      url: issue.html_url,
-      createdAt: issue.created_at,
-      updatedAt: issue.updated_at,
-      author: issue.user?.login ?? null,
-    });
-  } catch (error: any) {
-    console.error('GitHub MCP create issue error:', error);
-    res.status(500).json({
-      error: 'Failed to create issue',
-      message: error.message,
-    });
-  }
-});
-
-// Create pull request
-router.post('/pull-requests', ensureAuthenticated, async (req, res) => {
-  try {
-    const { repo, title, body, head, base } = req.body ?? {};
-
-    if (!repo || typeof repo !== 'string') {
-      return res.status(400).json({
-        error: 'Repository is required',
-        message: 'Please provide the repository to create a pull request in.',
-      });
-    }
-
-    if (!title || typeof title !== 'string') {
-      return res.status(400).json({
-        error: 'Pull request title is required',
-        message: 'Please provide a valid pull request title.',
-      });
-    }
-
-    if (!head || !base) {
-      return res.status(400).json({
-        error: 'Branch information missing',
-        message: 'Both head and base branches are required to create a pull request.',
-      });
-    }
-
-    const coordinates = await resolveRepoCoordinates(req.user!.id, repo);
-    if (!coordinates) {
-      return res.status(400).json({
-        error: 'Unable to resolve repository owner',
-        message: 'Connect GitHub or provide the repository as "owner/name".',
-      });
-    }
-
-    const result = await githubRequest(
-      req.githubToken,
-      `https://api.github.com/repos/${coordinates.owner}/${coordinates.repo}/pulls`,
-      {
-        method: 'POST',
-        body: JSON.stringify({
-          title,
-          body,
-          head,
-          base,
-        }),
       },
     );
 
     if (result.error) {
       return res.status(result.error.status).json({ error: result.error.message });
     }
+    res.status(201).json(mapIssue(result.data));
+  } catch (error: any) {
+    console.error('GitHub MCP create issue error:', error);
+    res.status(500).json({ error: 'Failed to create issue', message: error.message });
+  }
+});
 
-    const pullRequest = result.data;
-    res.status(201).json({
-      number: pullRequest.number,
-      title: pullRequest.title,
-      body: pullRequest.body,
-      head,
-      base,
-      state: pullRequest.state,
-      url: pullRequest.html_url,
-      createdAt: pullRequest.created_at,
-      updatedAt: pullRequest.updated_at,
-      author: pullRequest.user?.login ?? null,
-    });
+// List pull requests for a repo
+router.get('/pull-requests', requireGithubToken, async (req: GithubRequestContext, res) => {
+  try {
+    const repoParam = typeof req.query.repo === 'string' ? req.query.repo : undefined;
+    if (!repoParam) {
+      return res.status(400).json({ error: 'repo query parameter required (owner/name)' });
+    }
+    const state = ((req.query.state as string) || 'open').toLowerCase();
+    if (!['open', 'closed', 'all'].includes(state)) {
+      return res.status(400).json({ error: 'state must be open, closed, or all' });
+    }
+
+    const coords = await resolveRepoCoordinates(req.user!.id, repoParam);
+    if (!coords) {
+      return res.status(400).json({ error: 'Unable to resolve repository' });
+    }
+
+    const params = new URLSearchParams({ state, per_page: '50' });
+    const url = `https://api.github.com/repos/${coords.owner}/${coords.repo}/pulls?${params.toString()}`;
+
+    const result = await githubRequest<any[]>(req.githubToken!, url, { method: 'GET' });
+    if (result.error) {
+      return res.status(result.error.status).json({ error: result.error.message });
+    }
+    res.json((result.data ?? []).map(mapPullRequest));
+  } catch (error: any) {
+    console.error('GitHub MCP list PRs error:', error);
+    res.status(500).json({ error: 'Failed to fetch pull requests', message: error.message });
+  }
+});
+
+// Create pull request
+router.post('/pull-requests', requireGithubToken, async (req: GithubRequestContext, res) => {
+  try {
+    const { repo, title, body, head, base } = req.body ?? {};
+    if (!repo || typeof repo !== 'string') {
+      return res.status(400).json({ error: 'Repository is required' });
+    }
+    if (!title || typeof title !== 'string') {
+      return res.status(400).json({ error: 'Pull request title is required' });
+    }
+    if (!head || !base) {
+      return res.status(400).json({ error: 'Both head and base branches are required' });
+    }
+
+    const coords = await resolveRepoCoordinates(req.user!.id, repo);
+    if (!coords) {
+      return res.status(400).json({ error: 'Unable to resolve repository' });
+    }
+
+    const result = await githubRequest<any>(
+      req.githubToken!,
+      `https://api.github.com/repos/${coords.owner}/${coords.repo}/pulls`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ title, body, head, base }),
+      },
+    );
+
+    if (result.error) {
+      return res.status(result.error.status).json({ error: result.error.message });
+    }
+    res.status(201).json(mapPullRequest(result.data));
   } catch (error: any) {
     console.error('GitHub MCP create PR error:', error);
-    res.status(500).json({
-      error: 'Failed to create pull request',
-      message: error.message,
-    });
+    res.status(500).json({ error: 'Failed to create pull request', message: error.message });
   }
 });
 

--- a/server/mcp/api/memory.ts
+++ b/server/mcp/api/memory.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Router } from 'express';
 import { ensureAuthenticated } from '../../middleware/auth';
 import { v4 as uuidv4 } from 'uuid';
@@ -6,29 +5,21 @@ import { memoryMCP } from '../servers/memory-mcp';
 
 const router = Router();
 
-const toIsoString = (value: any) => {
-  if (!value) {
-    return new Date().toISOString();
-  }
-
-  if (value instanceof Date) {
-    return value.toISOString();
-  }
-
+const toIsoString = (value: any): string => {
+  if (!value) return new Date().toISOString();
+  if (value instanceof Date) return value.toISOString();
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? new Date().toISOString() : date.toISOString();
 };
 
+router.use(ensureAuthenticated);
+
 // Search memory
-router.post('/search', ensureAuthenticated, async (req, res) => {
+router.post('/search', async (req, res) => {
   try {
     const { query, type, limit } = req.body ?? {};
-
     if (!query || typeof query !== 'string') {
-      return res.status(400).json({
-        error: 'Query is required',
-        message: 'Please provide a search query.',
-      });
+      return res.status(400).json({ error: 'Query is required' });
     }
 
     const normalizedLimit = Math.min(Math.max(parseInt(limit, 10) || 10, 1), 50);
@@ -37,7 +28,6 @@ router.post('/search', ensureAuthenticated, async (req, res) => {
     const results = await Promise.all(
       nodes.map(async (node) => {
         const edges = await memoryMCP.getEdges(node.id, 'both');
-
         return {
           id: node.id,
           type: node.type,
@@ -53,22 +43,19 @@ router.post('/search', ensureAuthenticated, async (req, res) => {
     res.json(results);
   } catch (error: any) {
     console.error('Memory MCP search error:', error);
-    res.status(500).json({
-      error: 'Search failed',
-      message: error.message,
-    });
+    res.status(500).json({ error: 'Search failed', message: error.message });
   }
 });
 
 // Get conversation history
-router.get('/conversations', ensureAuthenticated, async (req, res) => {
+router.get('/conversations', async (req, res) => {
   try {
     const userId = String(req.user!.id);
     const sessionId = req.query.sessionId as string | undefined;
     const limit = Math.min(Math.max(parseInt(req.query.limit as string, 10) || 200, 1), 500);
 
     const history = await memoryMCP.getConversationHistory(userId, sessionId, limit);
-    const conversations = new Map();
+    const conversations = new Map<string, any>();
 
     for (const entry of history) {
       const existing = conversations.get(entry.sessionId) || {
@@ -82,7 +69,9 @@ router.get('/conversations', ensureAuthenticated, async (req, res) => {
 
       existing.messages += 1;
 
-      const timestamp = entry.timestamp instanceof Date ? entry.timestamp : new Date(entry.timestamp);
+      const timestamp = entry.timestamp instanceof Date
+        ? entry.timestamp
+        : new Date(entry.timestamp);
       if (!existing.firstTimestamp || timestamp < existing.firstTimestamp) {
         existing.firstTimestamp = timestamp;
       }
@@ -115,40 +104,32 @@ router.get('/conversations', ensureAuthenticated, async (req, res) => {
     res.json(response);
   } catch (error: any) {
     console.error('Memory MCP conversations error:', error);
-    res.status(500).json({
-      error: 'Failed to fetch conversations',
-      message: error.message,
-    });
+    res.status(500).json({ error: 'Failed to fetch conversations', message: error.message });
   }
 });
 
 // Create memory node
-router.post('/nodes', ensureAuthenticated, async (req, res) => {
+router.post('/nodes', async (req, res) => {
   try {
     const { type, content, metadata, embedding } = req.body ?? {};
-
-    if (!type || typeof type !== 'string') {
+    const allowedTypes = ['concept', 'entity', 'event', 'fact', 'idea'] as const;
+    type AllowedType = typeof allowedTypes[number];
+    if (!type || typeof type !== 'string' || !(allowedTypes as readonly string[]).includes(type)) {
       return res.status(400).json({
-        error: 'Type is required',
-        message: 'Please provide a valid node type.',
+        error: 'Type must be one of: ' + allowedTypes.join(', '),
       });
     }
-
     if (!content || typeof content !== 'string') {
-      return res.status(400).json({
-        error: 'Content is required',
-        message: 'Please provide node content.',
-      });
+      return res.status(400).json({ error: 'Content is required' });
     }
 
     const userId = req.user?.id;
-    const username = req.user?.username || 'system';
     if (!userId) {
       return res.status(401).json({ error: 'Not authenticated' });
     }
 
     const node = await memoryMCP.createNode({
-      type,
+      type: type as AllowedType,
       content,
       metadata: {
         ...(metadata || {}),
@@ -166,23 +147,17 @@ router.post('/nodes', ensureAuthenticated, async (req, res) => {
       connections: 0,
       createdAt: toIsoString(node.createdAt),
       lastAccessed: toIsoString(node.updatedAt),
-      createdAt: (node.createdAt instanceof Date ? node.createdAt : new Date(node.createdAt)).toISOString(),
-      lastAccessed: (node.updatedAt instanceof Date ? node.updatedAt : new Date(node.updatedAt)).toISOString(),
     });
   } catch (error: any) {
     console.error('Memory MCP create node error:', error);
-    res.status(500).json({
-      error: 'Failed to create memory node',
-      message: error.message,
-    });
+    res.status(500).json({ error: 'Failed to create memory node', message: error.message });
   }
 });
 
 // Create edge between nodes
-router.post('/edges', ensureAuthenticated, async (req, res) => {
+router.post('/edges', async (req, res) => {
   try {
     const { fromId, toId, relationship, weight, metadata } = req.body ?? {};
-
     if (!fromId || !toId || !relationship) {
       return res.status(400).json({
         error: 'Invalid edge payload',
@@ -206,32 +181,24 @@ router.post('/edges', ensureAuthenticated, async (req, res) => {
       weight: edge.weight,
       metadata: edge.metadata || {},
       createdAt: toIsoString(edge.createdAt),
-      createdAt: (edge.createdAt instanceof Date ? edge.createdAt : new Date(edge.createdAt)).toISOString(),
     });
   } catch (error: any) {
     console.error('Memory MCP create edge error:', error);
-    res.status(500).json({
-      error: 'Failed to create connection',
-      message: error.message,
-    });
+    res.status(500).json({ error: 'Failed to create connection', message: error.message });
   }
 });
 
 // Save conversation
-router.post('/conversations', ensureAuthenticated, async (req, res) => {
+router.post('/conversations', async (req, res) => {
   try {
     const { title, messages, sessionId: providedSessionId } = req.body ?? {};
-
     if (!Array.isArray(messages) || messages.length === 0) {
-      return res.status(400).json({
-        error: 'Messages required',
-        message: 'Provide at least one conversation message to persist.',
-      });
+      return res.status(400).json({ error: 'At least one message required' });
     }
 
     const sessionId = providedSessionId || uuidv4();
     const userId = String(req.user!.id);
-    const persistedMessages: any[] = [];
+    const persisted: any[] = [];
 
     for (const message of messages) {
       if (!message || typeof message.content !== 'string' || !message.role) {
@@ -251,35 +218,23 @@ router.post('/conversations', ensureAuthenticated, async (req, res) => {
           title: message.metadata?.title || title,
         },
       );
-
-      persistedMessages.push(saved);
+      persisted.push(saved);
     }
 
-    const firstMessage = persistedMessages[0];
-    const lastMessage = persistedMessages[persistedMessages.length - 1];
+    const first = persisted[0];
+    const last = persisted[persisted.length - 1];
 
     res.status(201).json({
       id: sessionId,
-      title: title || lastMessage?.metadata?.title || firstMessage?.content?.slice(0, 80) || 'Conversation',
-      messages: persistedMessages.length,
+      title: title || last?.metadata?.title || first?.content?.slice(0, 80) || 'Conversation',
+      messages: persisted.length,
       userId,
-      createdAt: toIsoString(firstMessage?.timestamp),
-      updatedAt: toIsoString(lastMessage?.timestamp),
-      createdAt: (firstMessage?.timestamp instanceof Date
-        ? firstMessage.timestamp
-        : new Date(firstMessage?.timestamp || Date.now())
-      ).toISOString(),
-      updatedAt: (lastMessage?.timestamp instanceof Date
-        ? lastMessage.timestamp
-        : new Date(lastMessage?.timestamp || Date.now())
-      ).toISOString(),
+      createdAt: toIsoString(first?.timestamp),
+      updatedAt: toIsoString(last?.timestamp),
     });
   } catch (error: any) {
     console.error('Memory MCP save conversation error:', error);
-    res.status(500).json({
-      error: 'Failed to save conversation',
-      message: error.message,
-    });
+    res.status(500).json({ error: 'Failed to save conversation', message: error.message });
   }
 });
 

--- a/server/mcp/api/postgres.ts
+++ b/server/mcp/api/postgres.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Router } from 'express';
 import { ensureAuthenticated } from '../../middleware/auth';
 import { DatabaseManagementService } from '../../services/database-management-service';
@@ -7,19 +6,17 @@ const router = Router();
 const databaseService = new DatabaseManagementService();
 
 const formatBytes = (bytes: number): string => {
-  if (!bytes || Number.isNaN(bytes)) {
-    return '0 B';
-  }
-
+  if (!bytes || Number.isNaN(bytes)) return '0 B';
   const units = ['B', 'KB', 'MB', 'GB', 'TB'];
   const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
   const value = bytes / Math.pow(1024, exponent);
-
   return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[exponent]}`;
 };
 
+router.use(ensureAuthenticated);
+
 // Get database tables
-router.get('/tables', ensureAuthenticated, async (req, res) => {
+router.get('/tables', async (req, res) => {
   try {
     const schemaFilter = (req.query.schema as string) || undefined;
     const tables = await databaseService.getTables();
@@ -36,10 +33,9 @@ router.get('/tables', ensureAuthenticated, async (req, res) => {
         sizeBytes: table.sizeInBytes,
         size: formatBytes(table.sizeInBytes),
         columnCount: table.columns.length,
-        indexCount: table.indexes.length,
         indexCount: (table.indexes ?? []).length,
         lastModified: table.lastModified ?? null,
-      }))
+      })),
     );
   } catch (error: any) {
     console.error('PostgreSQL MCP tables error:', error);
@@ -51,28 +47,22 @@ router.get('/tables', ensureAuthenticated, async (req, res) => {
 });
 
 // Get table schema
-router.get('/schema/:table', ensureAuthenticated, async (req, res) => {
+router.get('/schema/:table', async (req, res) => {
   try {
     const { table } = req.params;
     const schemaName = (req.query.schema as string) || 'public';
 
-    const [columns, indexes, constraints] = await Promise.all([
-      databaseService.getTableSchema(table, schemaName),
-      postgresMCP.getTableIndexes(table, schemaName),
-      postgresMCP.getTableConstraints(table, schemaName),
-    ]);
+    const columns = await databaseService.getTableSchema(table, schemaName);
 
-    res.json({
-      columns: columns.map((column) => ({
+    res.json(
+      columns.map((column) => ({
         column: column.name,
         type: column.type,
         nullable: column.nullable,
         default: column.defaultValue,
         isPrimary: column.isPrimaryKey,
       })),
-      indexes,
-      constraints,
-    });
+    );
   } catch (error: any) {
     console.error('PostgreSQL MCP schema error:', error);
     res.status(500).json({
@@ -83,10 +73,9 @@ router.get('/schema/:table', ensureAuthenticated, async (req, res) => {
 });
 
 // Execute query
-router.post('/query', ensureAuthenticated, async (req, res) => {
+router.post('/query', async (req, res) => {
   try {
-    const { query } = req.body;
-
+    const { query } = req.body ?? {};
     if (!query || typeof query !== 'string') {
       return res.status(400).json({
         error: 'Query must be provided as a string',
@@ -98,7 +87,6 @@ router.post('/query', ensureAuthenticated, async (req, res) => {
     }
 
     const result = await databaseService.executeQuery(query);
-
     if (result.error) {
       return res.status(400).json({
         error: result.error,
@@ -112,7 +100,7 @@ router.post('/query', ensureAuthenticated, async (req, res) => {
     const columns = result.rows.length ? Object.keys(result.rows[0]) : [];
     const rows = result.rows.map((row: any) => columns.map((column) => row[column]));
 
-    return res.json({
+    res.json({
       columns,
       rows,
       rowCount: result.rowCount,
@@ -120,7 +108,7 @@ router.post('/query', ensureAuthenticated, async (req, res) => {
     });
   } catch (error: any) {
     console.error('PostgreSQL MCP query error:', error);
-    return res.status(500).json({
+    res.status(500).json({
       error: 'Query execution failed',
       message: error.message,
       columns: [],
@@ -132,7 +120,7 @@ router.post('/query', ensureAuthenticated, async (req, res) => {
 });
 
 // Backup database
-router.post('/backup', ensureAuthenticated, async (req, res) => {
+router.post('/backup', async (req, res) => {
   try {
     const { description } = req.body || {};
     const backup = await databaseService.createBackup(description);

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -93,6 +93,7 @@ import publicFormsRouter from './public-forms.router';
 import projectAuthRouter from './project-auth.router';
 import statusRouter from './status.router';
 import mcpServersRouter from './mcp-servers.router';
+import mcpGlobalRouter from '../api/mcp';
 import networkingRouter from './networking.router';
 import videoRouter from './video.router';
 import { setupPreviewRoutes } from '../preview/preview-service';
@@ -564,6 +565,9 @@ export class MainRouter {
     app.use('/api/projects', tierRateLimiters.api, mcpServersRouter);
     app.use('/api/projects', tierRateLimiters.api, networkingRouter);
     app.use('/api/projects', tierRateLimiters.api, videoRouter);
+
+    // Global MCP Suite (GitHub, PostgreSQL, Memory) — distinct from per-project mcpServersRouter above
+    app.use('/api/mcp', tierRateLimiters.api, mcpGlobalRouter);
 
     // Multi-Device Sync routes (Workspace state, preferences, devices)
     app.use('/api/sync', tierRateLimiters.api, syncRouter);

--- a/server/services/agent-tool-framework.service.ts
+++ b/server/services/agent-tool-framework.service.ts
@@ -1332,6 +1332,177 @@ export class AgentToolFrameworkService extends EventEmitter {
       }
     });
 
+    // MCP Suite Tools — expose PostgreSQL, GitHub, and Memory MCP endpoints to the agent
+    this.registerTool({
+      name: 'mcp_postgres_query',
+      displayName: 'MCP: PostgreSQL Query',
+      description: 'Run a SQL query against the PostgreSQL MCP server. Returns columns + rows.',
+      capability: 'database',
+      inputSchema: z.object({
+        sql: z.string().describe('SQL query to execute'),
+        projectId: z.number().optional().describe('Optional project scope (for logging/audit)'),
+      }),
+      execute: async (input) => {
+        const { DatabaseManagementService } = await import('./database-management-service');
+        const svc = new DatabaseManagementService();
+        const queryUpper = input.sql.trim().toUpperCase();
+        const banned = ['DROP DATABASE', 'DROP SCHEMA', 'ALTER SYSTEM'];
+        for (const pattern of banned) {
+          if (queryUpper.includes(pattern)) {
+            return { success: false, error: `Blocked dangerous operation: ${pattern}` };
+          }
+        }
+        const result = await svc.executeQuery(input.sql);
+        if (result.error) {
+          return { success: false, error: result.error, executionTime: result.executionTime };
+        }
+        const columns = result.rows.length ? Object.keys(result.rows[0]) : [];
+        return {
+          success: true,
+          columns,
+          rows: result.rows.slice(0, 200),
+          rowCount: result.rowCount,
+          executionTime: result.executionTime,
+        };
+      },
+    });
+
+    this.registerTool({
+      name: 'mcp_github_search_issues',
+      displayName: 'MCP: GitHub Search Issues',
+      description: 'Search GitHub issues for the authenticated user. Optionally scope to a repo (owner/name).',
+      capability: 'api_integration',
+      inputSchema: z.object({
+        query: z.string().describe('Search terms'),
+        repo: z.string().optional().describe('Optional repo in owner/name form'),
+        state: z.enum(['open', 'closed', 'all']).optional().default('open'),
+      }),
+      execute: async (input, context) => {
+        const { githubOAuth } = await import('./github-oauth');
+        const userIdNum = typeof context.userId === 'string'
+          ? parseInt(context.userId, 10) || 0
+          : context.userId;
+        const token = await githubOAuth.getUserToken(userIdNum);
+        if (!token) {
+          return { success: false, error: 'GitHub not connected for this user' };
+        }
+
+        let url: string;
+        if (input.repo) {
+          const params = new URLSearchParams({ state: input.state ?? 'open', per_page: '30' });
+          url = `https://api.github.com/repos/${input.repo}/issues?${params.toString()}`;
+        } else {
+          const q = `${input.query} is:issue state:${input.state ?? 'open'} involves:@me`.trim();
+          const params = new URLSearchParams({ q, per_page: '30' });
+          url = `https://api.github.com/search/issues?${params.toString()}`;
+        }
+
+        const response = await fetch(url, {
+          headers: {
+            Accept: 'application/vnd.github+json',
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        if (!response.ok) {
+          const msg = await response.text().catch(() => response.statusText);
+          return { success: false, status: response.status, error: msg };
+        }
+        const body = (await response.json()) as any;
+        const items = Array.isArray(body) ? body : body?.items ?? [];
+        const issues = items
+          .filter((i: any) => !i.pull_request)
+          .map((issue: any) => ({
+            number: issue.number,
+            title: issue.title,
+            state: issue.state,
+            url: issue.html_url,
+            author: issue.user?.login ?? null,
+            createdAt: issue.created_at,
+            updatedAt: issue.updated_at,
+            repository: issue.repository_url?.split('/').slice(-2).join('/') ?? input.repo ?? null,
+          }));
+        return { success: true, count: issues.length, issues };
+      },
+    });
+
+    this.registerTool({
+      name: 'mcp_github_list_prs',
+      displayName: 'MCP: GitHub List Pull Requests',
+      description: 'List pull requests for a GitHub repository (owner/name).',
+      capability: 'api_integration',
+      inputSchema: z.object({
+        repo: z.string().describe('Repository in owner/name form'),
+        state: z.enum(['open', 'closed', 'all']).optional().default('open'),
+      }),
+      execute: async (input, context) => {
+        const { githubOAuth } = await import('./github-oauth');
+        const userIdNum = typeof context.userId === 'string'
+          ? parseInt(context.userId, 10) || 0
+          : context.userId;
+        const token = await githubOAuth.getUserToken(userIdNum);
+        if (!token) {
+          return { success: false, error: 'GitHub not connected for this user' };
+        }
+
+        const params = new URLSearchParams({ state: input.state ?? 'open', per_page: '30' });
+        const url = `https://api.github.com/repos/${input.repo}/pulls?${params.toString()}`;
+        const response = await fetch(url, {
+          headers: {
+            Accept: 'application/vnd.github+json',
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        if (!response.ok) {
+          const msg = await response.text().catch(() => response.statusText);
+          return { success: false, status: response.status, error: msg };
+        }
+        const body = (await response.json()) as any[];
+        const prs = body.map((pr: any) => ({
+          number: pr.number,
+          title: pr.title,
+          state: pr.state,
+          url: pr.html_url,
+          head: pr.head?.ref ?? null,
+          base: pr.base?.ref ?? null,
+          author: pr.user?.login ?? null,
+          createdAt: pr.created_at,
+          updatedAt: pr.updated_at,
+          mergedAt: pr.merged_at ?? null,
+        }));
+        return { success: true, count: prs.length, pullRequests: prs };
+      },
+    });
+
+    this.registerTool({
+      name: 'mcp_memory_search',
+      displayName: 'MCP: Memory Search',
+      description: 'Semantic search over the Memory MCP knowledge graph.',
+      capability: 'ai_analysis',
+      inputSchema: z.object({
+        query: z.string().describe('Search query'),
+        topK: z.number().optional().default(10).describe('Max results to return (1-50)'),
+        type: z.string().optional().describe('Optional node type filter'),
+      }),
+      execute: async (input) => {
+        const { memoryMCP } = await import('../mcp/servers/memory-mcp');
+        const limit = Math.min(Math.max(input.topK ?? 10, 1), 50);
+        const nodes = await memoryMCP.searchNodes(input.query, input.type, limit);
+        const results = await Promise.all(
+          nodes.map(async (node) => {
+            const edges = await memoryMCP.getEdges(node.id, 'both');
+            return {
+              id: node.id,
+              type: node.type,
+              content: node.content,
+              metadata: node.metadata || {},
+              connections: edges.length,
+            };
+          }),
+        );
+        return { success: true, count: results.length, results };
+      },
+    });
+
     // 10b. Write entire .env file content (with auditing + DB persistence)
     this.registerTool({
       name: 'write_env_file',


### PR DESCRIPTION
## Summary

Phase 1 of the 4-phase dead-panel revival — the MCP Suite (Model Context Protocol) is now fully functional: panels fetch real data, the dashboard is reachable from the IDE, and the AI agent can invoke MCP tools autonomously.

## What changed

### Server

**Mounted the global MCP router** in `server/routes/index.ts`:
```ts
app.use('/api/mcp', tierRateLimiters.api, mcpGlobalRouter);
```
This is separate from — and does not conflict with — the per-project `mcpServersRouter` that remains mounted at `/api/projects`.

**Endpoints now live at `/api/mcp/*`:**

| Method | Path | Notes |
| --- | --- | --- |
| GET | `/api/mcp/servers` | Dashboard metadata + per-server status |
| GET | `/api/mcp/tools` | List tools exposed by the MCP client (requires `ENABLE_MCP_SERVER=true`) |
| POST | `/api/mcp/tools/:name` | Invoke an MCP tool |
| GET | `/api/mcp/github/repositories` | List authenticated user repos |
| POST | `/api/mcp/github/repositories` | Create a repo |
| GET | `/api/mcp/github/issues` | **NEW** — list/search issues |
| POST | `/api/mcp/github/issues` | Create an issue |
| GET | `/api/mcp/github/pull-requests` | **NEW** — list PRs for a repo (state=open/closed/all) |
| POST | `/api/mcp/github/pull-requests` | Create a PR |
| GET | `/api/mcp/postgres/tables` | List DB tables |
| GET | `/api/mcp/postgres/schema/:table` | Table schema |
| POST | `/api/mcp/postgres/query` | Run SQL |
| POST | `/api/mcp/postgres/backup` | Create backup |
| POST | `/api/mcp/memory/search` | Semantic search |
| GET | `/api/mcp/memory/conversations` | Conversation history |
| POST | `/api/mcp/memory/conversations` | Save conversation |
| POST | `/api/mcp/memory/nodes` | Create memory node |
| POST | `/api/mcp/memory/edges` | Create memory edge |

**Fixed broken stubs** in `server/mcp/api/github.ts`, `postgres.ts`, `memory.ts`:
- Removed `@ts-nocheck`.
- Repaired `GET /repositories` (referenced `error` before it was declared).
- Removed phantom `createGitHubClient` / `octokit` call on `POST /repositories`.
- Removed phantom `postgresMCP.getTableIndexes/Constraints` that are not awaited by the panel.
- Removed duplicate keys in Memory MCP responses (`createdAt`, `lastAccessed`).
- Added proper token-resolution middleware (`requireGithubToken` via `githubOAuth.getUserToken`).

### Client

**Fixed the 4 MCP panels** (`client/src/components/MCPServersPanel.tsx`, `client/src/components/mcp/{PostgreSQL,GitHub,Memory}MCPPanel.tsx`):
- Removed `@ts-nocheck` from each.
- Fixed `apiRequest` misuse — this codebase's `apiRequest` already returns parsed JSON, so `.ok` / `.json()` calls were removed.
- Replaced the deprecated `useQuery({ onSuccess })` in `GitHubMCPPanel` with a `useEffect` on the query data (TanStack v5 pattern).
- Replaced hardcoded green "Connected" badges with real status derived from query state (loading / error / success).
- Rewrote `MCPServersPanel` as a real dashboard: reads live status from `GET /api/mcp/servers` and navigates into the sub-panels for GitHub / PostgreSQL / Memory.

**Wired into the IDE layout**:
- New `mcp-suite` activity bar entry (Brain icon) in `ReplitActivityBar`.
- Lazy-loaded `MCPServersPanel` via `instrumentedLazy` in `UnifiedIDELayout`, rendered for both the desktop tab (`currentTab.id === 'mcp-suite'`) and the mobile path (`mobileActiveTab === 'mcp-suite'`).
- Registered `'mcp-suite'` in `availableTools` and extended the `MobileTab` union so `handleAddTool('mcp-suite')` works end to end.
- The existing per-project `MCPPanel` (activity bar `mcp` → `/api/projects/:id/mcp/servers`) is untouched.

### Agent tools

Registered four new tools in `agent-tool-framework.service.ts` so the AI agent can invoke MCP-backed capabilities autonomously. They use the existing `registerTool` + zod `inputSchema` pattern and flow through `executeTool` with validation, rate limits, and the audit trail:

| Tool | Capability | Input |
| --- | --- | --- |
| `mcp_postgres_query` | database | `{ sql: string, projectId?: number }` |
| `mcp_github_search_issues` | api_integration | `{ query: string, repo?: string, state?: open\|closed\|all }` |
| `mcp_github_list_prs` | api_integration | `{ repo: string, state?: open\|closed\|all }` |
| `mcp_memory_search` | ai_analysis | `{ query: string, topK?: number, type?: string }` |

All four appear via `GET /api/agent/tools` alongside the other built-in agent tools.

## Validation

- `tsc --noEmit --pretty false --skipLibCheck` (with `NODE_OPTIONS=--max-old-space-size=8192`): **0 new errors**. Two pre-existing errors in `ReplitMultiplayers.tsx` (`handleWebSocketMessage` used before declaration) are unrelated — confirmed by running tsc on `main` without my changes.
- Booted `tsx server/index.ts` with a dummy `DATABASE_URL`: server bound to its port and registered all routes. No import errors, no module resolution errors. Only failures are from the dummy DB credentials (expected).
- `pnpm dev` / `npm run dev` was not run end to end in the browser — no manual browser verification was performed in this environment.

## Out of scope

- The core MCP server (`server/mcp/server.ts`) and SimpleHttpTransport wiring behind `ENABLE_MCP_SERVER=true` — only the HTTP shim at `/api/mcp/*` is wired up; the WebSocket transport and `getMCPClient()` flow was not modified.
- Per-project MCP servers (`mcpServersRouter` mounted at `/api/projects`) — untouched by design.
- Repo-wide lint (`@eslint/js` is unresolvable project-wide, unrelated to these changes).
- The two pre-existing `ReplitMultiplayers.tsx` TypeScript errors.

## Test plan

- [ ] `GET /api/mcp/servers` returns the 3 main servers with statuses.
- [ ] Open the IDE → click the Brain "MCP Suite" icon in the activity bar → dashboard renders with GitHub / PostgreSQL / Memory cards.
- [ ] Click into PostgreSQL → list tables, inspect schema, run a SELECT.
- [ ] Click into GitHub (with a connected GitHub account) → repositories load; creating an issue targets the right `/api/mcp/github/issues`.
- [ ] Click into Memory → search, create node, list conversation history.
- [ ] In an agent session, verify `mcp_postgres_query`, `mcp_github_list_prs`, `mcp_github_search_issues`, and `mcp_memory_search` are listed via `/api/agent/tools` and callable via `executeTool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
